### PR TITLE
PCHR-2545: Add missing component scenarios

### DIFF
--- a/casper_scripts/components/crm-error.js
+++ b/casper_scripts/components/crm-error.js
@@ -1,0 +1,11 @@
+'use strict';
+
+module.exports = function (casper, scenario, vp) {
+  var Page = require('../page-objects/form-page.js');
+  var page = new Page(casper, scenario, vp);
+
+  casper.then(function () {
+    page.submit();
+    page.waitForUrlChange();
+  });
+};

--- a/casper_scripts/page-objects/crm-page.js
+++ b/casper_scripts/page-objects/crm-page.js
@@ -7,26 +7,107 @@ var CrmPage = function (casper, scenario, viewPort) {
 };
 
 CrmPage.prototype = Object.create({
-  waitForSelectorAndEvaluate: function (fnExecInBrowser, targetSelector) {
-    var args = arguments;
-    this.casper.waitForSelector(targetSelector, function () {
-      this.evaluate.apply(this, args);
-    }, function () {
-      this.echo('Selector "' + targetSelector + '" not found', 'WARN_BAR');
-    }, 8000);
+  /**
+   * Adds a css class to the specified element.
+   *
+   * @param {String} targetSelector - the css selector for the target element.
+   * @param {String} className - the class name to add to the element.
+   */
+  addClassToElement: function (targetSelector, className) {
+    this.waitForSelectorAndEvaluate(function (selector, newClass) {
+      document.querySelector(selector).classList.add(newClass);
+    }, targetSelector, className);
   },
+
+  /**
+   * Changes the current active tab.
+   *
+   * @param {String} targetSelector - the css selector for the new tab that will
+   * become the active one.
+   */
+  changeTab: function (targetSelector) {
+    this.waitForSelectorAndEvaluate(function (selector) {
+      var ariaAttribute = '[aria-labelledby="' + selector.split('#')[1] + '"]';
+
+      document.querySelector('.ui-tabs-active')
+        .classList.remove('ui-tabs-active', 'ui-state-active');
+      document.querySelector('.crm-tab-button' + ariaAttribute)
+        .classList.add('ui-tabs-active', 'ui-state-active');
+
+      Array.prototype.map.call(
+        document.querySelectorAll('.ui-tabs-panel'), function (tab) {
+          tab.style.display = 'none';
+          return tab.style.display;
+        }
+      );
+
+      document.querySelector('.ui-tabs-panel' + ariaAttribute)
+        .style.display = 'block';
+    }, targetSelector);
+  },
+
+  /**
+   * Waits and clicks every element that matches the target selector.
+   *
+   * @param {String} targetSelector - the css selector of the target elements to
+   * click.
+   */
+  clickAll: function (targetSelector) {
+    this.waitForSelectorAndEvaluate(function (selector) {
+      Array.prototype.forEach.call(
+        document.querySelectorAll(selector),
+        function (el) {
+          el.click();
+        }
+      );
+    }, targetSelector);
+  },
+
+  /**
+   * Waits and clicks the first element that matches the target selector.
+   *
+   * @param {String} targetSelector - The css selector of the target element to
+   * click.
+   */
   clickFirst: function (targetSelector) {
     this.waitForSelectorAndEvaluate(function (selector) {
       document.querySelector(selector).click();
     }, targetSelector);
   },
-  clickAll: function (targetSelector) {
+
+  /**
+   * Closes all active alert messages.
+   */
+  closeAllAlertMsgBlocks: function () {
+    this.clickAll('.alert-danger > a.close');
+  },
+
+  /**
+   * Closes all active notifications.
+   */
+  closeErrorNotifications: function () {
+    this.clickAll('a.ui-notify-cross.ui-notify-close');
+  },
+
+  /**
+   * Hides the target element by setting its display property to none.
+   *
+   * @param {String} targetSelector - the css selector for the element to hide.
+   */
+  hideElement: function (targetSelector) {
     this.waitForSelectorAndEvaluate(function (selector) {
-      Array.prototype.forEach.call(document.querySelectorAll(selector), function (el) {
-        el.click();
-      });
+      document.querySelector(selector).style.display = 'none';
     }, targetSelector);
   },
+
+  /**
+   * Changes the width and height of the target element.
+   *
+   * @param {String} targetSelector - the css selector for the element that will
+   * be resized.
+   * @param {String|Number} width - the new width for the target element.
+   * @param {String|Number} height - the new height for the target element.
+   */
   resizeElement: function (targetSelector, width, height) {
     this.waitForSelectorAndEvaluate(function (selector, width, height) {
       var el = document.querySelector(selector);
@@ -34,32 +115,22 @@ CrmPage.prototype = Object.create({
       el.style.height = height;
     }, targetSelector, width, height);
   },
-  addClassToElement: function (targetSelector, className) {
-    this.waitForSelectorAndEvaluate(function (selector, newClass) {
-      document.querySelector(selector).classList.add(newClass);
-    }, targetSelector, className);
-  },
-  closeAllAlertMsgBlocks: function () {
-    this.clickAll('.alert-danger > a.close');
-  },
-  closeErrorNotifications: function () {
-    this.clickAll('a.ui-notify-cross.ui-notify-close');
-  },
-  hideElement: function(targetSelector) {
-    this.waitForSelectorAndEvaluate(function (selector) {
-      document.querySelector(selector).style.display = 'none';
-    }, targetSelector);
-  },
-  changeTab: function(targetSelector) {
-    this.waitForSelectorAndEvaluate(function (selector) {
-      document.querySelector('.ui-tabs-active').classList.remove('ui-tabs-active', 'ui-state-active');
-      document.querySelector('.crm-tab-button[aria-labelledby="' + selector.split('#')[1] + '"]').classList.add('ui-tabs-active', 'ui-state-active');
 
-      Array.prototype.map.call(document.querySelectorAll('.ui-tabs-panel'), function(tab) {
-        return tab.style.display = 'none';
-      });
-      document.querySelector('.ui-tabs-panel[aria-labelledby="' + selector.split('#')[1] + '"]').style.display = 'block';
-    }, targetSelector);
+  /**
+   * Waits for an element and then evaluates a function on the browser.
+   *
+   * @param {Function} fnExecInBrowser - the callback function to be executed in
+   * the browser after the target element is ready.
+   * @param {String} targetSelector - the css selector for the element to wait
+   * for.
+   */
+  waitForSelectorAndEvaluate: function (fnExecInBrowser, targetSelector) {
+    var args = arguments;
+    this.casper.waitForSelector(targetSelector, function () {
+      this.evaluate.apply(this, args);
+    }, function () {
+      this.echo('Selector "' + targetSelector + '" not found', 'WARN_BAR');
+    }, 8000);
   }
 });
 

--- a/casper_scripts/page-objects/crm-page.js
+++ b/casper_scripts/page-objects/crm-page.js
@@ -131,6 +131,17 @@ CrmPage.prototype = Object.create({
     }, function () {
       this.echo('Selector "' + targetSelector + '" not found', 'WARN_BAR');
     }, 8000);
+  },
+
+  /**
+   * Waits for the URL to change.
+   */
+  waitForUrlChange: function () {
+    var oldUrl = this.casper.getCurrentUrl();
+
+    return this.casper.waitFor(function () {
+      return oldUrl !== this.casper.getCurrentUrl();
+    }.bind(this));
   }
 });
 

--- a/casper_scripts/page-objects/form-page.js
+++ b/casper_scripts/page-objects/form-page.js
@@ -7,6 +7,74 @@ var FormPage = function (casper, scenario, viewPort) {
 };
 
 FormPage.prototype = Object.create(CrmPage.prototype, {
+  /**
+   * Focuses on the specified select2 dropdown.
+   *
+   * @param {String} select2ContainerSelector - the css selector for the select2
+   * dropdown to focus on.
+   */
+  activateSelect2: {
+    value: function (select2ContainerSelector) {
+      this.waitForSelectorAndEvaluate(function (selector) {
+        var event = document.createEvent('Event');
+        event.initEvent('focus', true, true);
+        document.querySelector(selector).dispatchEvent(event);
+      }, select2ContainerSelector + ' input');
+    }
+  },
+
+  /**
+   * Blurs out of the specified select2 dropdown.
+   *
+   * @param {String} select2ContainerSelector - the css selector for the select2
+   * dropdown to blur out of.
+   */
+  blurSelect2: {
+    value: function (select2ContainerSelector) {
+      this.waitForSelectorAndEvaluate(function (selector) {
+        var event = document.createEvent('Event');
+        event.initEvent('blur', true, true);
+        document.querySelector(selector).dispatchEvent(event);
+      }, select2ContainerSelector + ' input');
+    }
+  },
+
+  /**
+   * Clicks on a specific option inside the currently active select2 dropdown.
+   *
+   * @param {Number} nth - the number of the option to click on. This is a zero
+   * based index.
+   */
+  clickSelect2NthOption: {
+    value: function (nth) {
+      var selector = '.select2-drop-active li:nth-of-type(' + nth + ')';
+      this.waitForSelectorAndEvaluate(function (selector) {
+        var event = document.createEvent('MouseEvent');
+        event.initMouseEvent('mouseup', true, true);
+        document.querySelector(selector).dispatchEvent(event);
+      }, selector);
+    }
+  },
+
+  /**
+   * Disables a specific select2 dropdown.
+   *
+   * @param {String} select2ContainerSelector - the select2 dropdown to disable.
+   */
+  disableSelect2: {
+    value: function (select2ContainerSelector) {
+      this.addClassToElement(
+        select2ContainerSelector,
+        'select2-container-disabled'
+      );
+    }
+  },
+
+  /**
+   * Opens the speficied select2 dropdown.
+   *
+   * @param {String} select2ContainerSelector - the select2 dropdown to open.
+   */
   openSelect2DropDown: {
     value: function (select2ContainerSelector) {
       this.waitForSelectorAndEvaluate(function (selector) {
@@ -23,47 +91,21 @@ FormPage.prototype = Object.create(CrmPage.prototype, {
       }, select2ContainerSelector + ' .select2-choice');
     }
   },
+
+  /**
+   * Opens the specified select2 dropdown of the multiple type.
+   *
+   * @param {String} select2ContainerSelector - the select2 dropdown to open.
+   */
   openSelect2MultipleDropDown: {
     value: function (select2ContainerSelector) {
       this.waitForSelectorAndEvaluate(function (selector) {
         document.querySelector(selector).click();
       }, select2ContainerSelector + ' .select2-choices');
     }
-  },
-  clickSelect2NthOption: {
-    value: function (nth) {
-      var selector = '.select2-drop-active li:nth-of-type(' + nth + ')';
-      this.waitForSelectorAndEvaluate(function (selector) {
-        var event = document.createEvent('MouseEvent');
-        event.initMouseEvent('mouseup', true, true);
-        document.querySelector(selector).dispatchEvent(event);
-      }, selector);
-    }
-  },
-  activateSelect2: {
-    value: function (select2ContainerSelector) {
-      this.waitForSelectorAndEvaluate(function (selector) {
-        var event = document.createEvent('Event');
-        event.initEvent('focus', true, true);
-        document.querySelector(selector).dispatchEvent(event);
-      }, select2ContainerSelector + ' input');
-    }
-  },
-  disableSelect2: {
-    value: function (select2ContainerSelector) {
-      this.addClassToElement(select2ContainerSelector, 'select2-container-disabled');
-    }
-  },
-  blurSelect2: {
-    value: function (select2ContainerSelector) {
-      this.waitForSelectorAndEvaluate(function (selector) {
-        var event = document.createEvent('Event');
-        event.initEvent('blur', true, true);
-        document.querySelector(selector).dispatchEvent(event);
-      }, select2ContainerSelector + ' input');
-    }
   }
 });
+
 FormPage.prototype.constructor = FormPage;
 
 module.exports = FormPage;

--- a/casper_scripts/page-objects/form-page.js
+++ b/casper_scripts/page-objects/form-page.js
@@ -103,6 +103,15 @@ FormPage.prototype = Object.create(CrmPage.prototype, {
         document.querySelector(selector).click();
       }, select2ContainerSelector + ' .select2-choices');
     }
+  },
+
+  /**
+   * Submits the current page form.
+   */
+  submit: {
+    value: function () {
+      this.clickFirst('#content form .crm-form-submit');
+    }
   }
 });
 

--- a/scenarios/components.json
+++ b/scenarios/components.json
@@ -1,0 +1,30 @@
+{
+  "viewports": [
+    {
+      "name": "desktop",
+      "width": 1920,
+      "height": 900
+    }
+  ],
+  "onBeforeScript": "login.js",
+  "scenarios": [
+    {
+      "label": "Component - CRM Error",
+      "url": "{url}/civicrm/admin/leaveandabsences/periods?action=add&reset=1",
+      "onReadyScript": "common/close-notifications",
+      "onReadyScript": "components/crm-error"
+    }
+  ],
+  "paths": {
+    "bitmaps_reference": "./backstop_data/screenshots/contributions-menu/reference",
+    "bitmaps_test": "./backstop_data/screenshots/contributions-menu/test",
+    "compare_data": "./backstop_data/screenshots/contributions-menu/compare.json",
+    "casper_scripts": "./casper_scripts"
+  },
+  "engine": "phantomjs",
+  "report": ["CLI", "browser"],
+  "cliExitOnFail": false,
+  "casperFlags": ["--log-level=info"],
+  "debug": false,
+  "port": 3001
+}


### PR DESCRIPTION
This PR adds a new scenario aimed at specific CiviCRM HTML components. The first of these components is the `crm-error` element.

## CRM Error scenario

![1091495558_component_-_crm_error_0_document_0_desktop](https://user-images.githubusercontent.com/1642119/30821183-f26763be-a1d0-11e7-9754-74844c689970.png)

## Technical Details

* This commit https://github.com/compucorp/backstopjs-config/pull/1/commits/5b03d59645e17f4d9c25f85684e311ac7cc1f0f8 updates the **crm-page.js** and **form-page.js** page objects so they follow the style guide.

* A **submit** method was added on **form-page.js**:
  ```js
  submit: {
    value: function () {
      this.clickFirst('#content form .crm-form-submit');
    }
  }
  ```
  And to use it you can do this `formPage.submit()`.

  This method will only submit the main form inside the page and ignore any other forms such as the contact search, etc.

* A **waitForUrlChange** method was added to **crm-page.js**:
  ```js
  waitForUrlChange: function () {
    var oldUrl = this.casper.getCurrentUrl();

    return this.casper.waitFor(function () {
      return oldUrl !== this.casper.getCurrentUrl();
    }.bind(this));
  }
  ```

  This method allows Casper to wait until the URL changes, which can be used to wait for a page change after a link is clicked or a form is submitted.

  To use it you can do this `page.waitForUrlChange()`.

* A **components** folder was created which should include all scripts aimed to test CRM components. In this case a script to test `crm-error` elements was added.



