### PR TITLE
NDI-32: Added missing scenarios of vanilla CiviCRM

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@
 - [x] New Contribution
 - [x] Find Contribution
 - [x] Contribution Reports
-- [ ] Import Contributions
+- [x] Import Contributions
 - [x] Pledges - Dashboard
 - [x] Pledges - New Pledges
 - [x] Pledges - Find Pledges
@@ -84,7 +84,7 @@
 - [x] Register Event Participant
 - [x] Find Participants
 - [x] Event Reports
-- [ ] Import Participants
+- [x] Import Participants
 - [x] New Event
 - [x] Manage Events
 
@@ -107,26 +107,122 @@
 
 ## Memberships menu
 - [x] Dashboard
-- [ ] New Membership
+- [x] New Membership
 - [x] Find Memberships
 - [x] Membership Reports
 - [x] Batch Data Entry
-- [ ] Import Memberships
+- [x] Import Memberships
 
 
 ## Administer menu
 
+### Administration Console
+  - [x] System Status
+  - [x] Configuration Checklist
+
 ### Customize Data and Screens
-- [x] Custom Fields
-- [x] New Custom Field
-- [x] Profiles
-- [x] Tags
-- [x] Activity Types
-- [x] Relationship Types
-- [x] Contact Types
-- [x] Display Preferences
-- [x] Search Preferences
-- [x] Date Preferences
-- [x] Navigation Preferences
-- [x] World Replacements
-- [x] Manage Custom Searches
+  - [x] Custom Fields
+  - [x] New Custom Field
+  - [x] Profiles
+    - [x] Name and Address - CiviCRM Profile Fields
+  - [x] Tags
+  - [x] Activity Types
+  - [x] Relationship Types
+  - [x] Contact Types
+  - [x] Dropdown Options
+    - [x] Gender Options
+    - [x] Individual contact prefixes Options
+    - [x] Individual contact suffixes Options
+    - [x] Instant Messenger (IM) screen-names Options
+    - [x] Location Types (Home, Work...)
+    - [x] Mobile Phone Providers Options
+    - [x] Phone Type Options
+    - [x] Website Type Options
+  - [x] Display Preferences
+  - [x] Search Preferences
+  - [x] Date Preferences
+  - [x] Navigation Preferences
+  - [x] World Replacements
+  - [x] Manage Custom Searches
+
+### Communications
+  - [x] Organization Address and Contact Info
+  - [x] Message Templates
+  - [x] New Message Template
+  - [x] Schedule Reminders
+  - [x] Preferred Communication Methods
+  - [x] Label Formats
+  - [x] Print Page (PDF) Formats
+  - [x] Communication Style Options
+  - [x] Email Greeting Type Options
+  - [x] Postal Greeting Type Options
+  - [x] Addressee Type Options
+
+### Localization
+  - [x] Settings
+  - [x] Addresses
+  - [x] Date
+  - [x] Languages Options
+
+### Users and Permissions
+  - [x] Access Control
+  - [x] Synchronize Users to Contacts
+
+### System Settings
+  - [x] Enable Components
+  - [x] Connections
+  - [x] Extensions
+  - [x] Cleanup Caches and Update Paths
+  - [x] Debugging and Error Handling
+  - [x] Upload Directories
+  - [x] Import/Export Mappings
+  - [x] Mapping and Geocoding Providers
+  - [x] Misc
+  - [x] Option Groups
+  - [x] Payment Processor
+  - [x] Resource URLs
+  - [x] Safe File Extension Options
+  - [x] Scheduled Jobs
+  - [x] SMS Provider
+
+### CiviReport
+  - [x] All Reports
+  - [x] Create New Report from Template
+  - [x] Manage Templates
+  - [x] Register Report
+
+### CiviMember
+  - [x] Membership Types
+  - [x] Membership Status Rules
+  - [x] Component Settings
+
+### CiviCampaign
+  - [ ] Survey Types
+  - [ ] Campaign Types
+  - [ ] Campaign Status
+  - [ ] Engagement Index
+  - [ ] CiviCampaign Component Settings
+
+### CiviContribute
+  - [x] Financial Types
+  - [x] Financial Accounts
+  - [x] Payment Methods Options
+  - [x] Accepted Credit Cards Options
+  - [x] Soft Credit Types Options
+  - [x] Payment Processor
+  - [x] Payment Processor
+
+### CiviEvent
+  - [x] Event Templates
+  - [x] Event Type Options
+  - [x] Participant Status
+  - [x] Participant Role Options
+  - [x] Participant Listing Options
+  - [x] Event Name Badge Layouts
+  - [x] New Event Name Badge Layout
+  - [x] CiviEvent Component Settings
+
+### CiviMail
+  - [x] Mail Accounts
+  - [x] CiviMail Settings
+  - [x] CiviMail Component Settings

--- a/scenarios/administer-menu.json
+++ b/scenarios/administer-menu.json
@@ -20,6 +20,30 @@
       "onBeforeScript": "login.js"
     },
     {
+      "label": "CiviCRM System Status",
+      "url": "{url}/civicrm/a/#/status",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Configuration Checklist",
+      "url": "{url}/civicrm/admin/configtask?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
       "label": "Custom Fields List",
       "url": "{url}/civicrm/admin/custom/group/field?reset=1&action=browse&gid=1",
       "hideSelectors": [],
@@ -80,8 +104,32 @@
       "misMatchThreshold": 0.1
     },
     {
-      "label": "Customize Data and Screens - Profiles",
+      "label": "New CiviCRM Profile",
       "url": "{url}/civicrm/admin/uf/group?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Customize Data and Screens - Profiles",
+      "url": "{url}/civicrm/admin/uf/group/add?action=add&reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Name and Address - CiviCRM Profile Fields",
+      "url": "{url}/civicrm/admin/uf/group/field?reset=1&action=browse&gid=1",
       "hideSelectors": [],
       "removeSelectors": [],
       "selectors": [
@@ -130,6 +178,102 @@
     {
       "label": "Customize Data and Screens - Contact Types",
       "url": "{url}/civicrm/admin/options/subtype?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Customize Data and Screens - Gender Options",
+      "url": "{url}/civicrm/admin/options/gender?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Customize Data and Screens - Individual contact prefixes Options",
+      "url": "{url}/civicrm/admin/options/individual_prefix?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Customize Data and Screens - Individual contact suffixes Options",
+      "url": "{url}/civicrm/admin/options/individual_suffix?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Customize Data and Screens - Instant Messenger (IM) screen-names Options",
+      "url": "{url}/civicrm/admin/options/instant_messenger_service?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Customize Data and Screens - Location Types (Home, Work...)",
+      "url": "{url}/civicrm/admin/locationType?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Customize Data and Screens - Mobile Phone Providers Options",
+      "url": "{url}/civicrm/admin/options/mobile_provider?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Customize Data and Screens - Phone Type Options",
+      "url": "{url}/civicrm/admin/options/phone_type?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Customize Data and Screens - Website Type Options",
+      "url": "{url}/civicrm/admin/options/website_type?reset=1",
       "hideSelectors": [],
       "removeSelectors": [],
       "selectors": [
@@ -202,6 +346,486 @@
     {
       "label": "Customize Data and Screens - Manage Custom Searches",
       "url": "{url}/civicrm/admin/options/custom_search?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Communications - Organization Address and Contact Info",
+      "url": "{url}/civicrm/admin/domain?action=update&reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Communications - Message Templates",
+      "url": "{url}/civicrm/admin/messageTemplates?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Communications - New Message Template",
+      "url": "{url}/civicrm/admin/messageTemplates/add?action=add&reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Communications - Schedule Reminders",
+      "url": "{url}/civicrm/admin/scheduleReminders?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Communications - Schedule Reminders",
+      "url": "{url}/civicrm/admin/options/preferred_communication_method?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Communications - Label Formats",
+      "url": "{url}/civicrm/admin/labelFormats?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Communications - Print Page (PDF) Formats",
+      "url": "{url}/civicrm/admin/pdfFormats?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Communications - Communication Style Options",
+      "url": "{url}/civicrm/admin/options/communication_style?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Communications - Email Greeting Type Options",
+      "url": "{url}/civicrm/admin/options/email_greeting?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Communications - Postal Greeting Type Options",
+      "url": "{url}/civicrm/admin/options/postal_greeting?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Communications - Addressee Type Options",
+      "url": "{url}/civicrm/admin/options/addressee?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Communications - Addressee Type Options",
+      "url": "{url}/civicrm/admin/options/addressee?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Localization - Settings",
+      "url": "{url}/civicrm/admin/setting/localization?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Localization - Addresses",
+      "url": "{url}/civicrm/admin/setting/preferences/address?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Localization - Date",
+      "url": "{url}/civicrm/admin/setting/date?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Localization - Languages Options",
+      "url": "{url}/civicrm/admin/options/languages?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Users and Permissions - Access Control",
+      "url": "{url}/civicrm/admin/access?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Users and Permissions - Synchronize Users to Contacts",
+      "url": "{url}/civicrm/admin/synchUser?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "System Settings - Enable Components",
+      "url": "{url}/civicrm/admin/setting/component?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "System Settings - Connections",
+      "url": "{url}/civicrm/a/#/cxn",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "System Settings - Extensions",
+      "url": "{url}/civicrm/admin/extensions?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "System Settings - Cleanup Caches and Update Paths",
+      "url": "{url}/civicrm/admin/setting/updateConfigBackend?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "System Settings - Debugging and Error Handling",
+      "url": "{url}/civicrm/admin/setting/debug?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "System Settings - Upload Directories",
+      "url": "{url}/civicrm/admin/setting/path?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "System Settings - Import/Export Mappings",
+      "url": "{url}/civicrm/admin/mapping?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "System Settings - Mapping and Geocoding Providers",
+      "url": "{url}/civicrm/admin/setting/mapping?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "System Settings - Misc",
+      "url": "{url}/civicrm/admin/setting/misc?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "System Settings - Option Groups",
+      "url": "{url}/civicrm/admin/options?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "System Settings - Payment Processor",
+      "url": "{url}/civicrm/admin/paymentProcessor?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "System Settings - Resource URLs",
+      "url": "{url}/civicrm/admin/setting/url?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "System Settings - Safe File Extension Options",
+      "url": "{url}/civicrm/admin/options/safe_file_extension?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "System Settings - Scheduled Jobs",
+      "url": "{url}/civicrm/admin/job?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "System Settings - SMS Provider",
+      "url": "{url}/civicrm/admin/sms/provider?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "CiviReport - Report Template",
+      "url": "{url}/civicrm/admin/report/register?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "CiviReport - Report Template",
+      "url": "{url}/civicrm/admin/report/register?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "CiviCRM Reports",
+      "url": "{url}/civicrm/report/list?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Registered Templates",
+      "url": "{url}/civicrm/admin/report/options/report_template?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "CiviMember - Membership Types",
+      "url": "{url}/civicrm/admin/member/membershipType?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "CiviMember - Membership Status Rules",
+      "url": "{url}/civicrm/admin/member/membershipStatus?reset=1",
+      "hideSelectors": [],
+      "removeSelectors": [],
+      "selectors": [
+        "body"
+      ],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "CiviMember - Component Settings",
+      "url": "{url}/civicrm/admin/setting/preferences/member?reset=1",
       "hideSelectors": [],
       "removeSelectors": [],
       "selectors": [

--- a/scenarios/administer-menu.json
+++ b/scenarios/administer-menu.json
@@ -404,7 +404,7 @@
       "misMatchThreshold": 0.1
     },
     {
-      "label": "Communications - Schedule Reminders",
+      "label": "Communications - Preferred Communication Methods",
       "url": "{url}/civicrm/admin/options/preferred_communication_method?reset=1",
       "hideSelectors": [],
       "removeSelectors": [],
@@ -466,18 +466,6 @@
     {
       "label": "Communications - Postal Greeting Type Options",
       "url": "{url}/civicrm/admin/options/postal_greeting?reset=1",
-      "hideSelectors": [],
-      "removeSelectors": [],
-      "selectors": [
-        "body"
-      ],
-      "readyEvent": null,
-      "delay": 0,
-      "misMatchThreshold": 0.1
-    },
-    {
-      "label": "Communications - Addressee Type Options",
-      "url": "{url}/civicrm/admin/options/addressee?reset=1",
       "hideSelectors": [],
       "removeSelectors": [],
       "selectors": [
@@ -764,8 +752,8 @@
       "misMatchThreshold": 0.1
     },
     {
-      "label": "CiviReport - Report Template",
-      "url": "{url}/civicrm/admin/report/register?reset=1",
+      "label": "CiviReport - Create New Report from Template",
+      "url": "{url}/civicrm/admin/report/template/list?reset=1",
       "hideSelectors": [],
       "removeSelectors": [],
       "selectors": [

--- a/scenarios/components.json
+++ b/scenarios/components.json
@@ -10,7 +10,7 @@
   "scenarios": [
     {
       "label": "Component - CRM Error",
-      "url": "{url}/civicrm/admin/leaveandabsences/periods?action=add&reset=1",
+      "url": "{url}/civicrm/group/add?reset=1",
       "onReadyScript": "common/close-notifications",
       "onReadyScript": "components/crm-error"
     }

--- a/scenarios/contributions-menu.json
+++ b/scenarios/contributions-menu.json
@@ -58,6 +58,14 @@
       "misMatchThreshold": 0.1
     },
     {
+      "label": "Import Contributions",
+      "url": "{url}/civicrm/contribute/import?reset=1",
+      "selectors": ["body"],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
       "label": "Pledges - Dashboard",
       "url": "{url}/civicrm/pledge?reset=1",
       "selectors": ["body"],
@@ -232,6 +240,62 @@
     {
       "label": "Close Accounting Period",
       "url": "{url}/civicrm/admin/contribute/closeaccperiod?reset=1",
+      "selectors": ["body"],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Financial Types",
+      "url": "{url}/civicrm/admin/financial/financialType?reset=1",
+      "selectors": ["body"],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Financial Accounts",
+      "url": "{url}/civicrm/admin/financial/financialAccount?reset=1",
+      "selectors": ["body"],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Payment Methods Options",
+      "url": "{url}/civicrm/admin/options/payment_instrument?reset=1",
+      "selectors": ["body"],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Accepted Credit Cards Options",
+      "url": "{url}/civicrm/admin/options/accept_creditcard?reset=1",
+      "selectors": ["body"],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Soft Credit Types Options",
+      "url": "{url}/civicrm/admin/options/soft_credit_type?reset=1",
+      "selectors": ["body"],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Payment Processor",
+      "url": "{url}/civicrm/admin/paymentProcessor?reset=1",
+      "selectors": ["body"],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "CiviContribute Component Settings",
+      "url": "{url}/civicrm/admin/setting/preferences/contribute?reset=1",
       "selectors": ["body"],
       "readyEvent": null,
       "delay": 0,

--- a/scenarios/events-menu.json
+++ b/scenarios/events-menu.json
@@ -63,6 +63,78 @@
       "readyEvent": null,
       "delay": 0,
       "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Import Participants",
+      "url": "{url}/civicrm/event/import?reset=1",
+      "selectors": ["body"],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Event Templates",
+      "url": "{url}/civicrm/admin/eventTemplate?reset=1",
+      "selectors": ["body"],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Event Type Options",
+      "url": "{url}/civicrm/admin/options/event_type?reset=1",
+      "selectors": ["body"],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Participant Status",
+      "url": "{url}/civicrm/admin/participant_status?reset=1",
+      "selectors": ["body"],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Participant Role Options",
+      "url": "{url}/civicrm/admin/options/participant_role?reset=1",
+      "selectors": ["body"],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Participant Listing Options",
+      "url": "{url}/civicrm/admin/options/participant_listing?reset=1",
+      "selectors": ["body"],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Event Name Badge Layouts",
+      "url": "{url}/civicrm/admin/badgelayout?reset=1",
+      "selectors": ["body"],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "New Event Name Badge Layout",
+      "url": "{url}/civicrm/admin/badgelayout?action=add&reset=1",
+      "selectors": ["body"],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "CiviEvent Component Settings",
+      "url": "{url}/civicrm/admin/setting/preferences/event?reset=1",
+      "selectors": ["body"],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
     }
   ],
   "paths": {

--- a/scenarios/mailings-menu.json
+++ b/scenarios/mailings-menu.json
@@ -173,6 +173,30 @@
       "readyEvent": null,
       "delay": 0,
       "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Mail Accounts",
+      "url": "{url}/civicrm/admin/mailSettings?reset=1",
+      "selectors": ["body"],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "CiviMail Settings",
+      "url": "{url}/civicrm/admin/mail?reset=1",
+      "selectors": ["body"],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "CiviMail Component Settings",
+      "url": "{url}/civicrm/admin/setting/preferences/mailing?reset=1",
+      "selectors": ["body"],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
     }
   ],
   "paths": {

--- a/scenarios/membership-menu.json
+++ b/scenarios/membership-menu.json
@@ -24,6 +24,14 @@
       "misMatchThreshold": 0.1
     },
     {
+      "label": "Membership - New Membership",
+      "url": "{url}/civicrm/member/add?reset=1&action=add&context=standalone",
+      "selectors": ["body"],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
       "label": "Membership - Find Memberships - Results",
       "url": "{url}/civicrm/member/search?reset=1",
       "selectors": ["body"],
@@ -43,6 +51,14 @@
     {
       "label": "Membership - New Data Entry Batch",
       "url": "{url}/civicrm/batch/add?reset=1&action=add",
+      "selectors": ["body"],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1
+    },
+    {
+      "label": "Membership - Import Memberships",
+      "url": "{url}/civicrm/member/import?reset=1",
       "selectors": ["body"],
       "readyEvent": null,
       "delay": 0,


### PR DESCRIPTION
# Description:
This PR adds missing scenarios to get all pages tested when running BackstopJS tests.

# Technical details
### Remove L&A path from scenarios
https://github.com/compucorp/backstopjs-config/pull/3/commits/bfd7b3f00b09d6ab4c9a7d9000ed130df9aa554d changes path for testing error component to `/civicrm/group/add?reset=1` instead of calling L&A path `/civicrm/admin/leaveandabsences/periods?action=add&reset=1` which is not a part of vanilla CiviCRM

### Add new scenarios
https://github.com/compucorp/backstopjs-config/pull/3/commits/efbf673739635b42de5dfa69b599f12b66b0217e new scenarios which are part of default CiviCRM installation.

### Update readme file
We are updating README.md file to add new screens in the list