### PR TITLE
PCHR-3435: Use local backstop

### DIFF
--- a/test-runner.js
+++ b/test-runner.js
@@ -101,7 +101,7 @@ function writeTmpFile(data) {
 function execBackstopJS() {
   var task = argv.task || 'test';
 
-  var proc = exec('backstop ' + task + ' --configPath=tmp.json', function(error, stdout, stderr) {
+  var proc = exec('./node_modules/.bin/backstop ' + task + ' --configPath=tmp.json', function(error, stdout, stderr) {
     if (error) {
       console.error(error);
       throw error;


### PR DESCRIPTION
## Problem
Previously Backstop JS had to be installed globally to run the test suite.

## Solution
Changed to code to use local copy of Backstop JS instead.