### PR TITLE
NDI-85: Remove "seven" dependency

### DIFF
--- a/casper_scripts/administer-menu/connections.js
+++ b/casper_scripts/administer-menu/connections.js
@@ -1,0 +1,9 @@
+'use strict';
+module.exports = function (casper, scenario, vp) {
+  var Page = require('../page-objects/form-page.js');
+  var page = new Page(casper, scenario, vp);
+
+  casper.then(function () {
+    this.waitForSelector('.crm-connection-block');
+  });
+};

--- a/casper_scripts/administer-menu/edit-multiple-choice-options.js
+++ b/casper_scripts/administer-menu/edit-multiple-choice-options.js
@@ -1,0 +1,9 @@
+'use strict';
+module.exports = function (casper, scenario, vp) {
+  var Page = require('../page-objects/form-page.js');
+  var page = new Page(casper, scenario, vp);
+
+  casper.then(function () {
+    this.waitWhileVisible('.dataTables_processing');
+  });
+};

--- a/casper_scripts/administer-menu/system-status.js
+++ b/casper_scripts/administer-menu/system-status.js
@@ -1,0 +1,9 @@
+'use strict';
+module.exports = function (casper, scenario, vp) {
+  var Page = require('../page-objects/form-page.js');
+  var page = new Page(casper, scenario, vp);
+
+  casper.then(function () {
+    this.waitUntilVisible('.crm-status-item');
+  });
+};

--- a/casper_scripts/common/close-notifications.js
+++ b/casper_scripts/common/close-notifications.js
@@ -5,8 +5,6 @@ module.exports = function (casper, scenario, vp) {
 
   casper.then(function() {
     this.echo('Closing error notifications', 'INFO');
-    this.wait(1000);
     page.closeErrorNotifications();
-    this.wait(1000);
   });
 };

--- a/casper_scripts/contact-page/record-event.js
+++ b/casper_scripts/contact-page/record-event.js
@@ -6,6 +6,7 @@ module.exports = function (casper, scenario, vp) {
   require('./show-events')(casper, scenario, vp);
   casper.then(function () {
     page.clickFirst('.CRM_Event_Form_Search a[accesskey="N"]');
+    this.waitWhileSelector('.blockUI.blockOverlay');
     this.wait(1000);
   });
 };

--- a/casper_scripts/contact-page/record-membership.js
+++ b/casper_scripts/contact-page/record-membership.js
@@ -5,7 +5,7 @@ module.exports = function (casper, scenario, vp) {
 
   require('./show-memberships')(casper, scenario, vp);
   casper.then(function () {
-    page.clickFirst('#ui-id-7 a[accesskey="N"]');
+    page.clickFirst('a[accesskey="N"][href$="context=membership"]');
     this.waitWhileSelector('.blockUI.blockOverlay');
     this.wait(1000);
   });

--- a/casper_scripts/contact-page/show-contributions.js
+++ b/casper_scripts/contact-page/show-contributions.js
@@ -4,7 +4,7 @@ module.exports = function (casper, scenario, vp) {
   var page = new Page(casper, scenario, vp);
 
   casper.then(function () {
-    page.clickFirst('a#ui-id-2');
+    page.clickFirst('.crm-contact-tabs-list a[title="Contributions"]');
     this.wait(1000);
   });
 };

--- a/casper_scripts/contact/add-tag-set.js
+++ b/casper_scripts/contact/add-tag-set.js
@@ -1,0 +1,10 @@
+'use strict';
+module.exports = function (casper, scenario, vp) {
+  var Page = require('../page-objects/contact-page.js');
+  var page = new Page(casper, scenario, vp);
+
+  casper.then(function () {
+    page.clickFirst('a[href="#new-tagset"]');
+    this.waitWhileSelector('.blockUI.blockOverlay');
+  });
+};

--- a/casper_scripts/contact/add-tag.js
+++ b/casper_scripts/contact/add-tag.js
@@ -1,0 +1,10 @@
+'use strict';
+module.exports = function (casper, scenario, vp) {
+  var Page = require('../page-objects/contact-page.js');
+  var page = new Page(casper, scenario, vp);
+
+  casper.then(function () {
+    page.clickFirst('a[href^="/civicrm/tag/edit?action=add"]');
+    this.waitWhileSelector('.blockUI.blockOverlay');
+  });
+};

--- a/casper_scripts/contact/manage-groups.js
+++ b/casper_scripts/contact/manage-groups.js
@@ -1,0 +1,10 @@
+'use strict';
+module.exports = function (casper, scenario, vp) {
+  var Page = require('../page-objects/contact-page.js');
+  var page = new Page(casper, scenario, vp);
+
+  casper.then(function () {
+    require('../common/close-notifications')(casper, scenario, vp);
+    this.waitWhileSelector('.blockUI.blockOverlay');
+  });
+};

--- a/casper_scripts/contributions/new-pledge-filters.js
+++ b/casper_scripts/contributions/new-pledge-filters.js
@@ -4,6 +4,6 @@ module.exports = function (casper, scenario, vp) {
   var page = new Page(casper, scenario, vp);
 
   casper.then(function () {
-    page.changeTab('#ui-id-4');
+    page.clickFirst('a[href="#report-tab-set-filters"]');
   });
 };

--- a/casper_scripts/contributions/new-pledge-sorting.js
+++ b/casper_scripts/contributions/new-pledge-sorting.js
@@ -4,6 +4,6 @@ module.exports = function (casper, scenario, vp) {
   var page = new Page(casper, scenario, vp);
 
   casper.then(function () {
-    page.changeTab('#ui-id-3');
+    page.clickFirst('a[href="#report-tab-order-by-elements"]');
   });
 };

--- a/casper_scripts/mailings/attachments.js
+++ b/casper_scripts/mailings/attachments.js
@@ -4,6 +4,6 @@ module.exports = function (casper, scenario, vp) {
   var page = new Page(casper, scenario, vp);
 
   casper.then(function () {
-    page.changeTab('#ui-id-3');
+    page.clickFirst('a[href="#tab-attachment"]');
   });
 };

--- a/casper_scripts/mailings/mailing.js
+++ b/casper_scripts/mailings/mailing.js
@@ -4,6 +4,6 @@ module.exports = function (casper, scenario, vp) {
   var page = new Page(casper, scenario, vp);
 
   casper.then(function () {
-    page.clickFirst('a[href="#tab-header"]');
+    this.waitUntilVisible('.crm-wizard');
   });
 };

--- a/casper_scripts/mailings/message-workflow.js
+++ b/casper_scripts/mailings/message-workflow.js
@@ -4,6 +4,6 @@ module.exports = function (casper, scenario, vp) {
   var page = new Page(casper, scenario, vp);
 
   casper.then(function () {
-    this.click('a#ui-id-3');
+    this.click('a[title="System Workflow Messages"]');
   });
 };

--- a/casper_scripts/mailings/publication.js
+++ b/casper_scripts/mailings/publication.js
@@ -4,6 +4,6 @@ module.exports = function (casper, scenario, vp) {
   var page = new Page(casper, scenario, vp);
 
   casper.then(function () {
-    page.changeTab('#ui-id-5');
+    page.clickFirst('a[href="#tab-pub"]');
   });
 };

--- a/casper_scripts/mailings/responses.js
+++ b/casper_scripts/mailings/responses.js
@@ -4,6 +4,6 @@ module.exports = function (casper, scenario, vp) {
   var page = new Page(casper, scenario, vp);
 
   casper.then(function () {
-    page.changeTab('#ui-id-6');
+    page.clickFirst('a[href="#tab-response"]');
   });
 };

--- a/casper_scripts/mailings/tracking.js
+++ b/casper_scripts/mailings/tracking.js
@@ -4,6 +4,6 @@ module.exports = function (casper, scenario, vp) {
   var page = new Page(casper, scenario, vp);
 
   casper.then(function () {
-    page.changeTab('#ui-id-7');
+    page.clickFirst('a[href="#tab-tracking"]');
   });
 };

--- a/casper_scripts/membership/search-result.js
+++ b/casper_scripts/membership/search-result.js
@@ -6,5 +6,6 @@ module.exports = function (casper, scenario, vp) {
   require('../common/open-accordions')(casper, scenario, vp);
   casper.then(function () {
     page.clickFirst('#_qf_Search_refresh');
+    this.waitForSelector('.crm-results-block');
   });
 };

--- a/casper_scripts/page-objects/crm-page.js
+++ b/casper_scripts/page-objects/crm-page.js
@@ -20,33 +20,6 @@ CrmPage.prototype = Object.create({
   },
 
   /**
-   * Changes the current active tab.
-   *
-   * @param {String} targetSelector - the css selector for the new tab that will
-   * become the active one.
-   */
-  changeTab: function (targetSelector) {
-    this.waitForSelectorAndEvaluate(function (selector) {
-      var ariaAttribute = '[aria-labelledby="' + selector.split('#')[1] + '"]';
-
-      document.querySelector('.ui-tabs-active')
-        .classList.remove('ui-tabs-active', 'ui-state-active');
-      document.querySelector('.crm-tab-button' + ariaAttribute)
-        .classList.add('ui-tabs-active', 'ui-state-active');
-
-      Array.prototype.map.call(
-        document.querySelectorAll('.ui-tabs-panel'), function (tab) {
-          tab.style.display = 'none';
-          return tab.style.display;
-        }
-      );
-
-      document.querySelector('.ui-tabs-panel' + ariaAttribute)
-        .style.display = 'block';
-    }, targetSelector);
-  },
-
-  /**
    * Waits and clicks every element that matches the target selector.
    *
    * @param {String} targetSelector - the css selector of the target elements to

--- a/casper_scripts/page-objects/crm-page.js
+++ b/casper_scripts/page-objects/crm-page.js
@@ -59,7 +59,10 @@ CrmPage.prototype = Object.create({
    * Closes all active notifications.
    */
   closeErrorNotifications: function () {
-    this.clickAll('a.ui-notify-cross.ui-notify-close');
+    if (this.casper.exists('.ui-notify-message')) {
+      this.clickAll('a.ui-notify-cross.ui-notify-close');
+      this.casper.waitWhileSelector('.ui-notify-message');
+    }
   },
 
   /**

--- a/casper_scripts/page-objects/form-page.js
+++ b/casper_scripts/page-objects/form-page.js
@@ -110,7 +110,7 @@ FormPage.prototype = Object.create(CrmPage.prototype, {
    */
   submit: {
     value: function () {
-      this.clickFirst('#content form .crm-form-submit');
+      this.clickFirst('form .crm-form-submit');
     }
   }
 });

--- a/casper_scripts/page-objects/form-page.js
+++ b/casper_scripts/page-objects/form-page.js
@@ -110,7 +110,7 @@ FormPage.prototype = Object.create(CrmPage.prototype, {
    */
   submit: {
     value: function () {
-      this.clickFirst('form .crm-form-submit');
+      this.clickFirst('#crm-main-content-wrapper form .crm-form-submit:not(.cancel)');
     }
   }
 });

--- a/casper_scripts/search/actions/email-schedule-attachments.js
+++ b/casper_scripts/search/actions/email-schedule-attachments.js
@@ -5,6 +5,6 @@ module.exports = function (casper, scenario, vp) {
 
   casper.then(function () {
     require('./email-schedule')(casper, scenario, vp);
-    page.changeTab('#ui-id-3');
+    page.clickFirst('a[href="#tab-attachment"]');
   });
 };

--- a/casper_scripts/search/actions/email-schedule-header-footer.js
+++ b/casper_scripts/search/actions/email-schedule-header-footer.js
@@ -5,6 +5,6 @@ module.exports = function (casper, scenario, vp) {
 
   casper.then(function () {
     require('./email-schedule')(casper, scenario, vp);
-    page.changeTab('#ui-id-4');
+    page.clickFirst('a[href="#tab-header"]');
   });
 };

--- a/casper_scripts/search/actions/email-schedule-publication.js
+++ b/casper_scripts/search/actions/email-schedule-publication.js
@@ -5,6 +5,6 @@ module.exports = function (casper, scenario, vp) {
 
   casper.then(function () {
     require('./email-schedule')(casper, scenario, vp);
-    page.changeTab('#ui-id-5');
+    page.clickFirst('a[href="#tab-pub"]');
   });
 };

--- a/casper_scripts/search/actions/email-schedule-responses.js
+++ b/casper_scripts/search/actions/email-schedule-responses.js
@@ -5,6 +5,6 @@ module.exports = function (casper, scenario, vp) {
 
   casper.then(function () {
     require('./email-schedule')(casper, scenario, vp);
-    page.changeTab('#ui-id-6');
+    page.clickFirst('a[href="#tab-response"]');
   });
 };

--- a/casper_scripts/search/actions/email-schedule-tracking.js
+++ b/casper_scripts/search/actions/email-schedule-tracking.js
@@ -5,6 +5,6 @@ module.exports = function (casper, scenario, vp) {
 
   casper.then(function () {
     require('./email-schedule')(casper, scenario, vp);
-    page.changeTab('#ui-id-7');
+    page.clickFirst('a[href="#tab-tracking"]');
   });
 };

--- a/scenarios/administer-menu.json
+++ b/scenarios/administer-menu.json
@@ -583,7 +583,8 @@
       ],
       "readyEvent": null,
       "delay": 0,
-      "misMatchThreshold": 0.1
+      "misMatchThreshold": 0.1,
+      "onReadyScript": "administer-menu/connections"
     },
     {
       "label": "System Settings - Extensions",

--- a/scenarios/administer-menu.json
+++ b/scenarios/administer-menu.json
@@ -29,7 +29,8 @@
       ],
       "readyEvent": null,
       "delay": 0,
-      "misMatchThreshold": 0.1
+      "misMatchThreshold": 0.1,
+      "onReadyScript": "administer-menu/system-status"
     },
     {
       "label": "Configuration Checklist",

--- a/scenarios/administer-menu.json
+++ b/scenarios/administer-menu.json
@@ -102,7 +102,8 @@
       ],
       "readyEvent": null,
       "delay": 0,
-      "misMatchThreshold": 0.1
+      "misMatchThreshold": 0.1,
+      "onReadyScript": "administer-menu/edit-multiple-choice-options"
     },
     {
       "label": "New CiviCRM Profile",

--- a/scenarios/components.json
+++ b/scenarios/components.json
@@ -16,9 +16,9 @@
     }
   ],
   "paths": {
-    "bitmaps_reference": "./backstop_data/screenshots/contributions-menu/reference",
-    "bitmaps_test": "./backstop_data/screenshots/contributions-menu/test",
-    "compare_data": "./backstop_data/screenshots/contributions-menu/compare.json",
+    "bitmaps_reference": "./backstop_data/screenshots/components/reference",
+    "bitmaps_test": "./backstop_data/screenshots/components/test",
+    "compare_data": "./backstop_data/screenshots/components/compare.json",
     "casper_scripts": "./casper_scripts"
   },
   "engine": "phantomjs",

--- a/scenarios/contact-menu.json
+++ b/scenarios/contact-menu.json
@@ -169,15 +169,7 @@
       "misMatchThreshold": 0.1
     },
     {
-      "label": "New Tag",
-      "url": "{url}/civicrm/tag?reset=1&action=add",
-      "selectors": ["body"],
-      "readyEvent": null,
-      "delay": 0,
-      "misMatchThreshold": 0.1
-    },
-    {
-      "label": "Manage Tags",
+      "label": "Tags",
       "url": "{url}/civicrm/tag?reset=1",
       "selectors": ["body"],
       "readyEvent": null,
@@ -185,12 +177,22 @@
       "misMatchThreshold": 0.1
     },
     {
-      "label": "Add Tag set",
-      "url": "{url}/civicrm/tag?action=add&reset=1&tagset=1",
+      "label": "Tags - Add Tag",
+      "url": "{url}/civicrm/tag?reset=1&action=add",
       "selectors": ["body"],
       "readyEvent": null,
       "delay": 0,
-      "misMatchThreshold": 0.1
+      "misMatchThreshold": 0.1,
+      "onReadyScript": "contact/add-tag"
+    },
+    {
+      "label": "Tags - Add Tag set",
+      "url": "{url}/civicrm/tag?",
+      "selectors": ["body"],
+      "readyEvent": null,
+      "delay": 0,
+      "misMatchThreshold": 0.1,
+      "onReadyScript": "contact/add-tag-set"
     }
   ],
   "paths": {

--- a/scenarios/contact-menu.json
+++ b/scenarios/contact-menu.json
@@ -166,7 +166,8 @@
       "selectors": ["body"],
       "readyEvent": null,
       "delay": 0,
-      "misMatchThreshold": 0.1
+      "misMatchThreshold": 0.1,
+      "onReadyScript": "contact/manage-groups"
     },
     {
       "label": "Tags",

--- a/scenarios/mailings-menu.json
+++ b/scenarios/mailings-menu.json
@@ -13,7 +13,8 @@
       "readyEvent": null,
       "delay": 0,
       "misMatchThreshold": 0.1,
-      "onBeforeScript": "login.js"
+      "onBeforeScript": "login.js",
+      "onReadyScript": "mailings/mailing"
     },
     {
       "label": "New Mailings - Attachments",


### PR DESCRIPTION
Some of the scenarios relied on markup that is present only when the CiviCRM admin is using Drupal's "seven" theme, leading the erroneous results when using a different admin theme (for example, "Bartik").

This PR removes any "Seven" dependency and also fixes scenarios that #5 missed

## Selectors fixed
### Submit button
The `FormPage` object has a `submit`, which used this selector to find the "submit" button in a form
```css
#content form .crm-form-submit
```
There were two problems with this selector
1. The `#content` id exists only in the "Seven" theme
2. The class `.crm-form-submit` is applied not only to the submit button, but also to the cancel button. The only reason that the cancel button was never clicked is simply because the submit button comes first in the markup

Given the above, the selector had been changed to
```css
#crm-main-content-wrapper form .crm-form-submit:not(.cancel)
```

### Tabs
Tabs changes were accomplished by the `CrmPage.changeTab()` method, which had two problems
1. It was unnecessary complicated, manually doing all the style and class manipulations that could have been achieved by simply on the tab button
2. It required the consumer of the method to pass the id of the tab to select (`#ui-id-7`, `#ui-id-2`, etc), but the id of an individual tab changes depending on the current theme selected (ie. the tabs have different ids when using the "Bartik" theme than the ones they have when using the "Seven" theme), leading to unreliable results

As a result the the method was completely dropped, replaced by the `clickFirst` method, which can be then given a selector with the more meaningful `[href]` value of the tab button
```diff
- page.changeTab('#ui-id-7'); 
+ page.clickFirst('a[href="#tab-tracking"]');
```
## Improvements to `common/close-notifications.js`
The `common/close-notifications.js` script is used to close the toast notifications that civi shows on the top right corner.

Before this PR, the script would wait an arbitrary amount of time before and after calling the `CrmPage.closeErrorNotifications()` method (which is what actually closes the notification). The method itself was simply clicking on the notification's "close" button and nothing else

```js
// common/close-notifications.js
casper.then(function() {
  this.echo('Closing error notifications', 'INFO');
  this.wait(1000);
  page.closeErrorNotifications();
  this.wait(1000);
});

// page-objects/crm-page.js
closeErrorNotifications: function () {
   this.clickAll('a.ui-notify-cross.ui-notify-close');
}
```
The problems with this approach are that it:
1. always assumes that there is a notification to close, meaning that in some scenarios it will unnecessarily wait a certain amount of time before declaring that the element doesn't exist and moving on with the rest of the script
2. doesn't actually wait for the notification to fade out (as there is a fade out animation applied on the element when closed) and be removed from the DOM, it just waits one second and assumes that by then the notification will be gone. Unfortunately that's not always the case, which means that sometimes scenarios will report diffs because a screenshot was taken before the notification faded out completely.

The script was then refactored by
1. removing the arbitrary wait times,
2. always checking first if there is an actual notification to close
3. waiting for the notification to be absent from the DOM before continuing

```js
// common/close-notifications.js
casper.then(function() {
  this.echo('Closing error notifications', 'INFO');
  page.closeErrorNotifications();
});

// page-objects/crm-page.js
closeErrorNotifications: function () {
  if (this.casper.exists('.ui-notify-message')) {
    this.clickAll('a.ui-notify-cross.ui-notify-close');
    this.casper.waitWhileSelector('.ui-notify-message');
  }
}
```


