### PR TITLE
SHOR-26: Add missing screens for Home/Dashboard and Configure Dashboard screen

### DIFF
--- a/backstop_data/engine_scripts/puppet/dashboard/configure-dashboard.js
+++ b/backstop_data/engine_scripts/puppet/dashboard/configure-dashboard.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = async (engine) => {
+  await engine.click('#crm-dashboard-configure');
+  await engine.waitFor('#configure-dashlet', { visible: true });
+  await engine.waitFor('.blockUI.blockOverlay', { hidden: true });
+};

--- a/backstop_data/engine_scripts/puppet/mailings/ab-test-manage.js
+++ b/backstop_data/engine_scripts/puppet/mailings/ab-test-manage.js
@@ -2,9 +2,8 @@
 
 module.exports = async (engine, scenario, vp) => {
   await engine.waitFor('table.display', { visible: true });
-
-  // The list grows on each passing run, so we display only 10 rows in the test
+  // The list grows on each passing run, so we display only 2 rows in the test (First being the main row);
   await engine.evaluate(() => {
-    document.querySelectorAll('table.display tr:nth-child(n+10)').forEach(row => row.remove());
+    document.querySelectorAll('table.display tr:nth-child(n+3)').forEach(row => row.remove());
   });
 };

--- a/scenarios/dashboard.json
+++ b/scenarios/dashboard.json
@@ -1,0 +1,11 @@
+{
+  "scenarios": [{
+    "label": "Dashboard",
+    "url": "{url}/civicrm/dashboard"
+  },
+  {
+    "label": "Dashboard - Configure",
+    "url": "{url}/civicrm/dashboard",
+    "onReadyScript": "dashboard/configure-dashboard.js"
+  }]
+}


### PR DESCRIPTION
## PR contains
* Screen for Home Dashboard Screen
* Configure dashboard Dashboard
* Added a new group `home-dashboard` to the scenarios group list.
## Steps to test 
```shell
$ gulp backstopjs:reference --group home-dashboard && gulp backstopjs:test --group home-dashboard
```