### PR TITLE
SHOR-29: Add missing screens for Search builder result screen

### DIFF
--- a/backstop_data/engine_scripts/puppet/search/search-builder-results.js
+++ b/backstop_data/engine_scripts/puppet/search/search-builder-results.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = async (engine, scenario, vp) => {
+  await engine.select('select#mapper_1_0_0', 'Individual'); 
+  await engine.select('select#mapper_1_0_1', 'last_name');
+  await engine.select('select#operator_1_0', '=');
+  await engine.type('input#value_1_0', 'patel');
+  await engine.click('#_qf_Builder_refresh');
+  await engine.waitForNavigation();
+};

--- a/scenarios/search-menu.json
+++ b/scenarios/search-menu.json
@@ -44,6 +44,10 @@
       "hideSelectors": ["#mainTabContainer"]
     },
     {
+      "label": "Search Builder - Search result",
+      "url": "{url}/civicrm/contact/search/builder?reset=1"
+    },
+    {
       "label": "Find Participants",
       "url": "{url}/civicrm/event/search?reset=1",
       "hideSelectors": ["#mainTabContainer"]


### PR DESCRIPTION
## PR contains screens for
* Search Builder Result screen.
```shell
$ gulp backstopjs:reference --group search-menu && gulp backstopjs:test --group search-menu
```