### PR TITLE
SHOR-30: Add missing screens for Find memberships screens

### DIFF
--- a/backstop_data/engine_scripts/puppet/membership/find-memberships-delete.js
+++ b/backstop_data/engine_scripts/puppet/membership/find-memberships-delete.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = async (engine, scenario, vp) => {
+  await require('./search-result')(engine, scenario, vp);
+  await engine.click('tr:first-child span.crm-hover-button');
+  await engine.click('tr:first-child a[title="Delete Membership"]');
+  await engine.waitFor('.CRM_Member_Form_Membership', { visible: true });
+};

--- a/backstop_data/engine_scripts/puppet/membership/find-memberships-edit.js
+++ b/backstop_data/engine_scripts/puppet/membership/find-memberships-edit.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = async (engine, scenario, vp) => {
+  await require('./search-result')(engine, scenario, vp);
+  await engine.click('tr:first-child a[title="Edit Membership"]');
+  await engine.waitFor('.CRM_Member_Form_Membership', { visible: true });
+};

--- a/backstop_data/engine_scripts/puppet/membership/find-memberships-renew-cc.js
+++ b/backstop_data/engine_scripts/puppet/membership/find-memberships-renew-cc.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = async (engine, scenario, vp) => {
+  await require('./search-result')(engine, scenario, vp);
+  await engine.click('tr:first-child span.crm-hover-button');
+  await engine.click('tr:first-child a[title="Renew Membership Using Credit Card"]');
+  await engine.waitFor('.CRM_Member_Form_MembershipRenewal', { visible: true });
+};

--- a/backstop_data/engine_scripts/puppet/membership/find-memberships-renew.js
+++ b/backstop_data/engine_scripts/puppet/membership/find-memberships-renew.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = async (engine, scenario, vp) => {
+  await require('./search-result')(engine, scenario, vp);
+  await engine.click('tr:first-child span.crm-hover-button');
+  await engine.click('tr:first-child a[title="Renew Membership"]');
+  await engine.waitFor('.CRM_Member_Form_MembershipRenewal', { visible: true });
+};

--- a/backstop_data/engine_scripts/puppet/membership/find-memberships-view.js
+++ b/backstop_data/engine_scripts/puppet/membership/find-memberships-view.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = async (engine, scenario, vp) => {
+  await require('./search-result')(engine, scenario, vp);
+  await engine.click('tr:first-child a[title="View Membership"]');
+  await engine.waitFor('.CRM_Member_Form_MembershipView', { visible: true });
+};

--- a/scenarios/membership-menu.json
+++ b/scenarios/membership-menu.json
@@ -9,6 +9,36 @@
       "url": "{url}/civicrm/member/search?reset=1"
     },
     {
+      "label": "Find Memberships - View Modal - Results ",
+      "url": "{url}/civicrm/member/search?reset=1",
+      "selectors": [".ui-dialog"],
+      "onReadyScript": "membership/find-memberships-view.js"
+    },
+    {
+      "label": "Find Memberships - Edit Modal - Results ",
+      "url": "{url}/civicrm/member/search?reset=1",
+      "selectors": [".ui-dialog"],
+      "onReadyScript": "membership/find-memberships-edit.js"
+    },
+    {
+      "label": "Find Memberships - Delete Modal - Results ",
+      "url": "{url}/civicrm/member/search?reset=1",
+      "selectors": [".ui-dialog"],
+      "onReadyScript": "membership/find-memberships-delete.js"
+    },
+    {
+      "label": "Find Memberships - Renew Modal - Results ",
+      "url": "{url}/civicrm/member/search?reset=1",
+      "selectors": [".ui-dialog"],
+      "onReadyScript": "membership/find-memberships-renew.js"
+    },
+    {
+      "label": "Find Memberships - Renew Credit Card Modal - Results ",
+      "url": "{url}/civicrm/member/search?reset=1",
+      "selectors": [".ui-dialog"],
+      "onReadyScript": "membership/find-memberships-renew-cc.js"
+    },  
+    {
       "label": "Membership - New Membership",
       "url": "{url}/civicrm/member/add?reset=1&action=add&context=standalone"
     },


### PR DESCRIPTION
## PR contains screens for
* Search - Find Memberships Results - Delete Modal
<img width="416" alt="membership - delete modal" src="https://user-images.githubusercontent.com/3340537/41533002-d0afeefe-7316-11e8-95d3-534ead3d5d24.png">
* Search - Find Memberships Results - Renew Modal
<img width="1124" alt="membership renew modal" src="https://user-images.githubusercontent.com/3340537/41533354-1b77091c-7318-11e8-92b7-3af72e49ad6f.png">
* Search - Find Memberships Results - Renew-Credit Card Modal
<img width="1124" alt="membership Renew cc modal" src="https://user-images.githubusercontent.com/3340537/41533392-3b4ba9b4-7318-11e8-87b2-43062aa1887d.png">
* Search - Find Memberships Results - Edit Modal
<img width="1124" alt="membership edit modal" src="https://user-images.githubusercontent.com/3340537/41533031-f367e910-7316-11e8-9ba9-2bd91b21f9b3.png">
* Search - Find Memberships Results - View Modal
<img width="1109" alt="membership - view modal" src="https://user-images.githubusercontent.com/3340537/41533048-00706696-7317-11e8-8a48-5a1ee5754882.png">


```shell
$ gulp backstopjs:reference --group search-menu && gulp backstopjs:test --group search-menu
```