### PR TITLE
SHOR-31: Add missing screens for find participants and find activities screens

### DIFF
--- a/backstop_data/engine_scripts/puppet/search/find-activities-delete-modal.js
+++ b/backstop_data/engine_scripts/puppet/search/find-activities-delete-modal.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = async (engine, scenario, vp) => {
+  await require('./find-activities')(engine, scenario, vp);
+  await engine.click('a[title="Delete Activity"]');
+  await engine.waitFor('.CRM_Activity_Form_Activity', { visible: true });
+};

--- a/backstop_data/engine_scripts/puppet/search/find-activities-edit-modal.js
+++ b/backstop_data/engine_scripts/puppet/search/find-activities-edit-modal.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = async (engine, scenario, vp) => {
+  await require('./find-activities')(engine, scenario, vp);
+  await engine.click('a[title="Update Activity"]');
+  await engine.waitFor('.CRM_Activity_Form_Activity', { visible: true });
+  await require('../common/open-accordions')(engine, scenario, vp);
+};

--- a/backstop_data/engine_scripts/puppet/search/find-activities-view-modal.js
+++ b/backstop_data/engine_scripts/puppet/search/find-activities-view-modal.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = async (engine, scenario, vp) => {
+  await require('./find-activities')(engine, scenario, vp);
+  await engine.click('a[title="View Activity"]');
+  await engine.waitFor('.CRM_Activity_Form_Activity', { visible: true });
+};

--- a/backstop_data/engine_scripts/puppet/search/find-participants-delete-modal.js
+++ b/backstop_data/engine_scripts/puppet/search/find-participants-delete-modal.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = async (engine, scenario, vp) => {
+  await require('./find-participants')(engine, scenario, vp);
+  await engine.click('tr:first-child span.crm-hover-button');
+  await engine.click('tr:first-child a[title="Delete Participation"]');
+  await engine.waitFor('.CRM_Event_Form_Participant', { visible: true });  
+};

--- a/backstop_data/engine_scripts/puppet/search/find-participants-edit-modal.js
+++ b/backstop_data/engine_scripts/puppet/search/find-participants-edit-modal.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = async (engine, scenario, vp) => {
+  await require('./find-participants')(engine, scenario, vp);
+  await engine.click('tr:first-child a[title="Edit Participation"]');
+  await engine.waitFor('.CRM_Event_Form_Participant', { visible: true });  
+};

--- a/backstop_data/engine_scripts/puppet/search/find-participants-view-modal.js
+++ b/backstop_data/engine_scripts/puppet/search/find-participants-view-modal.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = async (engine, scenario, vp) => {
+  await require('./find-participants')(engine, scenario, vp);
+  await engine.click('tr:first-child a[title="View Participation"]');
+  await engine.waitFor('.CRM_Event_Form_ParticipantView', { visible: true });  
+};

--- a/scenarios/search-menu.json
+++ b/scenarios/search-menu.json
@@ -79,6 +79,24 @@
       "onReadyScript": "search/find-participants.js"
     },
     {
+      "label": "Find Participants - View Modal - results",
+      "url": "{url}/civicrm/event/search?reset=1",
+      "selectors": [".ui-dialog"],
+      "onReadyScript": "search/find-participants-view-modal.js"
+    },
+    {
+      "label": "Find Participants - Edit Modal - results",
+      "url": "{url}/civicrm/event/search?reset=1",
+      "selectors": [".ui-dialog"],
+      "onReadyScript": "search/find-participants-edit-modal.js"
+    },
+    {
+      "label": "Find Participants - Delete Modal - results",
+      "url": "{url}/civicrm/event/search?reset=1",
+      "selectors": [".ui-dialog"],
+      "onReadyScript": "search/find-participants-delete-modal.js"
+    },
+    {
       "label": "Find Activities",
       "url": "{url}/civicrm/activity/search?reset=1",
       "hideSelectors": ["#mainTabContainer"]
@@ -88,6 +106,24 @@
       "url": "{url}/civicrm/activity/search?reset=1",
       "hideSelectors": ["#mainTabContainer"],
       "onReadyScript": "search/find-activities.js"
+    },
+    {
+      "label": "Find Activities - View Modal - results",
+      "url": "{url}/civicrm/activity/search?reset=1",
+      "selectors": [".ui-dialog"],
+      "onReadyScript": "search/find-activities-view-modal.js"
+    },
+    {
+      "label": "Find Activities - Edit Modal - results",
+      "url": "{url}/civicrm/activity/search?reset=1",
+      "selectors": [".ui-dialog"],
+      "onReadyScript": "search/find-activities-edit-modal.js"
+    },
+    {
+      "label": "Find Activities - Delete Modal - results",
+      "url": "{url}/civicrm/activity/search?reset=1",
+      "selectors": [".ui-dialog"],
+      "onReadyScript": "search/find-activities-delete-modal.js"
     },
     {
       "label": "Custom Searches",


### PR DESCRIPTION
## PR contains screens for
* Search - Find Participants Results - View Modal
<img width="1127" alt="find participants - view modal" src="https://user-images.githubusercontent.com/3340537/41533815-bdd06dc4-7319-11e8-9ff2-58c607fc57a1.png">
* Search - Find Participants Results - Edit Modal
<img width="1138" alt="find participants - edit modal" src="https://user-images.githubusercontent.com/3340537/41533814-bda1499a-7319-11e8-865c-72eef0c335e2.png">
* Search - Find Participants Results - Delete Modal
<img width="432" alt="find participants delete modal" src="https://user-images.githubusercontent.com/3340537/41533817-be04ba70-7319-11e8-98bf-0d72b0c4eee7.png">
* Search - Find Activities Results - View
<img width="1136" alt="find activities - view activity modal" src="https://user-images.githubusercontent.com/3340537/41533813-bd7061ea-7319-11e8-90c3-86011825b876.png">
* Search - Find Activities Results - Edit
<img width="418" alt="find activities - edit modal" src="https://user-images.githubusercontent.com/3340537/41533812-bd3e4a7a-7319-11e8-943d-7b7c07179bb6.png">
* Search - Find Activities Results - Delete
<img width="418" alt="find activities - delete modal" src="https://user-images.githubusercontent.com/3340537/41533811-bd0f66e2-7319-11e8-83fb-7c76955351af.png">

```shell
$ gulp backstopjs:reference --group search-menu && gulp backstopjs:test --group search-menu
```