### PR TITLE
SHOR-33: Add missing screens for Add Group pages

### DIFF
--- a/backstop_data/engine_scripts/puppet/contact/add-new-group-step1.js
+++ b/backstop_data/engine_scripts/puppet/contact/add-new-group-step1.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * Function to generate random string of 5 chars.
+ */
+ 
+function generate_id(len) {
+  len = len || 5;
+  var text = "";
+  var possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
+  for (var i = 0; i < len; i++)
+    text += possible.charAt(Math.floor(Math.random() * possible.length));
+  return text;
+}
+
+module.exports = async (engine, scenario, vp) => {
+  await engine.type('input[name="title"]', 'Backstop test group - Automated Case - ' + generate_id());
+  await engine.type('textarea[name="description"]', 'Backstop test group description - Automated  - ' + generate_id());
+  await engine.click('#_qf_Edit_upload-bottom');
+  await engine.waitForNavigation();
+};

--- a/backstop_data/engine_scripts/puppet/contact/add-new-group-step2.js
+++ b/backstop_data/engine_scripts/puppet/contact/add-new-group-step2.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = async (engine, scenario, vp) => {
+  await require('./add-new-group-step1')(engine, scenario, vp);
+  await engine.type('input[name="sort_name"]', 'Patel');
+  await engine.click('#_qf_Basic_refresh');
+  await engine.waitForNavigation();
+};

--- a/backstop_data/engine_scripts/puppet/contact/add-new-group-step3.js
+++ b/backstop_data/engine_scripts/puppet/contact/add-new-group-step3.js
@@ -1,0 +1,8 @@
+'use strict';
+
+module.exports = async (engine, scenario, vp) => {
+  await require('./add-new-group-step2')(engine, scenario, vp);
+  engine.click('[title="Select All Rows"]  > input[name="toggleSelect"]');
+  await engine.click('#_qf_Basic_next_action');
+  await engine.waitForNavigation();
+};

--- a/backstop_data/engine_scripts/puppet/contact/add-new-group-view-selected-contacts.js
+++ b/backstop_data/engine_scripts/puppet/contact/add-new-group-view-selected-contacts.js
@@ -1,0 +1,7 @@
+'use strict';
+
+module.exports = async (engine, scenario, vp) => {
+  await require('./add-new-group-step3')(engine, scenario, vp);
+  await engine.click('a[title="View Selected Contacts"]');
+  await engine.waitForSelector('.dataTables_wrapper');
+};

--- a/scenarios/contact-menu.json
+++ b/scenarios/contact-menu.json
@@ -64,6 +64,27 @@
       "url": "{url}/civicrm/group/add?reset=1"
     },
     {
+      "label": "New Group - Add a new Group (Step1) ",
+      "url": "{url}/civicrm/group/add?reset=1",
+      "onReadyScript": "contact/add-new-group-step1.js"
+    },
+    {
+      "label": "New Group - Add a new Group - Search Results (Step2)",
+      "url": "{url}/civicrm/group/add?reset=1",
+      "onReadyScript": "contact/add-new-group-step2.js"
+    },
+    {
+      "label": "New Group - Add to group - Search Results - Add Contact to group (Step3)",
+      "url": "{url}/civicrm/group/add?reset=1",
+      "onReadyScript": "contact/add-new-group-step3.js"
+    },
+    {
+      "label": "New Group - Add to group - Search Results - Add Contact to group - View selected contacts",
+      "url": "{url}/civicrm/group/add?reset=1",
+      "selectors": [".ui-dialog"],
+      "onReadyScript": "contact/add-new-group-view-selected-contacts.js"
+    },
+    {
       "label": "Manage Groups",
       "url": "{url}/civicrm/group?reset=1",
       "onReadyScript": "contact/manage-groups.js"


### PR DESCRIPTION
### PR contains Screens for
* New Group - Add to group
![77041666_new_group_-_add_a_new_group_step1__0_document_0_desktop](https://user-images.githubusercontent.com/3340537/41596381-c7902e02-73e7-11e8-838b-5c215fb42b09.png)
* New Group - Add to group - Search Results
![77041666_new_group_-_add_a_new_group_-_search_results_step2_0_document_0_desktop](https://user-images.githubusercontent.com/3340537/41596380-c75cddcc-73e7-11e8-9f3b-d5302a479bfd.png)
* New Group - Add to group - Search Results - Add Contact to group
![77041666_new_group_-_add_to_group_-_search_results_-_add_contact_to_group_step3_0_document_0_desktop](https://user-images.githubusercontent.com/3340537/41596382-c7c1356a-73e7-11e8-8c27-09596df44c6d.png)
* New Group - Add to group - Search Results - Add Contact to group - View selected contacts
![77041666_new_group_-_add_to_group_-_search_results_-_add_contact_to_group_-_view_selected_contacts_0_ui-dialog_0_desktop](https://user-images.githubusercontent.com/3340537/41596178-1b9adbb0-73e7-11e8-9597-a55eb12f74b6.png)


#### Other Mentions
* `backstop_data/engine_scripts/puppet/contact/add-new-group-step1.js` file contains a function `generate_id` which is used to populate the New group *name* field with a new title every time as Every Group Name needs to be unique.
