### PR TITLE
SHOR-1: Hotfixes for Close all error notifictations and fixing random navigation timeouts for manage groups pages

### DIFF
--- a/backstop_data/engine_scripts/puppet/manage-groups/add-contacts-to-group-confirm.js
+++ b/backstop_data/engine_scripts/puppet/manage-groups/add-contacts-to-group-confirm.js
@@ -3,6 +3,8 @@
 module.exports = async (engine, scenario, vp) => {
   await require('./add-contacts-to-group-results')(engine, scenario, vp);
   await engine.click('[title="Select All Rows"]  > input[name="toggleSelect"]');
-  await engine.click('#_qf_Basic_next_action');
-  await engine.waitForNavigation();
+  await Promise.all([
+    engine.click('#_qf_Basic_next_action'),
+    engine.waitForNavigation()
+  ]);
 };

--- a/backstop_data/engine_scripts/puppet/manage-groups/add-contacts-to-group-search-form.js
+++ b/backstop_data/engine_scripts/puppet/manage-groups/add-contacts-to-group-search-form.js
@@ -3,5 +3,8 @@
 module.exports = async (engine, scenario, vp) => {
   await require('./add-contacts-to-group')(engine, scenario, vp);
   await engine.waitForSelector('.crm-submit-buttons a', {visible: true});
-  await engine.click('.crm-submit-buttons a');
+  await Promise.all([
+    engine.click('.crm-submit-buttons a'),
+    engine.waitForNavigation()
+  ]);  
 };

--- a/backstop_data/engine_scripts/puppet/manage-groups/add-contacts-to-group.js
+++ b/backstop_data/engine_scripts/puppet/manage-groups/add-contacts-to-group.js
@@ -2,5 +2,8 @@
 
 module.exports = async (engine, scenario, vp) => {
   await require('./manage-groups')(engine, scenario, vp);
-  await engine.click('a[title="Group Contacts"]');
+  await Promise.all([
+    engine.click('a[title="Group Contacts"]'),
+    engine.waitForNavigation()
+  ]);
 };

--- a/backstop_data/engine_scripts/puppet/page-objects/crm-page.js
+++ b/backstop_data/engine_scripts/puppet/page-objects/crm-page.js
@@ -42,11 +42,14 @@ module.exports = class CrmPage {
    * Closes all active notifications.
    */
   async closeErrorNotifications () {
-    const exists = !!(await this.engine.$('.ui-notify-message'));
-
-    if (exists) {
-      await this.engine.click('a.ui-notify-cross.ui-notify-close');
-      await this.engine.waitFor('.ui-notify-message', { hidden: true });
+    while(1) {
+      const exists = !!(await this.engine.$('.ui-notify-message'));
+      if (exists) {
+        await this.engine.click('a.ui-notify-cross.ui-notify-close');
+      } else {
+        await this.engine.waitFor('.ui-notify-message', { hidden: true });
+        return;
+      }
     }
   }
 


### PR DESCRIPTION
### PR contains 
 * Fix for Close all error notifications function 
##### Current issue
Initially it closes the first notification it finds and was timing out if page has multiple notifications
#####  Fix
Iterating the code till all notification windows are closed fixed the issue. 
See backstop_data/engine_scripts/puppet/page-objects/crm-page.js.

* Fix for some scenarios for manage groups which were throwing navigation time out randomly.
##### Current issue
Some scenarios for manage groups were throwing navigation time out randomly too much. After debugging more I found out that there was a race condition between browser page load and awaiting response from the `engine.click` event. So in layman terms the browsers loads to the next page till the Promise for engine.click resolves and so waitForNavigation always start on the new page and waits forever as the page is already loaded.
##### Fix
Starting both the Promise asynchronously did the magic. So `Promise.all` starts both the processes asynchronously and waits till both of them finishes allowing waitForNavigation to listen for the url change without any delays.

