### PR TITLE
SHOR-52: Fix markup for JS backstop test suite

### DIFF
--- a/backstop_data/engine_scripts/puppet/search/actions/common.js
+++ b/backstop_data/engine_scripts/puppet/search/actions/common.js
@@ -12,7 +12,7 @@
 module.exports = async (page, checkboxIds = ['103']) => {
   await page.clickSelect2Option('#s2id_contact_type', 'Organization');
   await page.clickAndWaitForNavigation('#_qf_Basic_refresh');
-
+  await page.engine.type('#sort_name', 'Alliance');
   for (const id of checkboxIds) {
     await page.engine.click(`#mark_x_${id}`);
   }

--- a/backstop_data/engine_scripts/puppet/search/actions/common.js
+++ b/backstop_data/engine_scripts/puppet/search/actions/common.js
@@ -9,8 +9,7 @@
  * @param {CrmPage} page
  * @param {Array} checkboxIds
  */
-module.exports = async (page, checkboxIds = ['3']) => {
-  await page.engine.type('#sort_name', 'Technology');
+module.exports = async (page, checkboxIds = ['103']) => {
   await page.clickSelect2Option('#s2id_contact_type', 'Organization');
   await page.clickAndWaitForNavigation('#_qf_Basic_refresh');
 

--- a/backstop_data/engine_scripts/puppet/search/actions/common.js
+++ b/backstop_data/engine_scripts/puppet/search/actions/common.js
@@ -13,6 +13,7 @@ module.exports = async (page, checkboxIds = ['103']) => {
   await page.clickSelect2Option('#s2id_contact_type', 'Organization');
   await page.clickAndWaitForNavigation('#_qf_Basic_refresh');
   await page.engine.type('#sort_name', 'Alliance');
+  
   for (const id of checkboxIds) {
     await page.engine.click(`#mark_x_${id}`);
   }

--- a/backstop_data/engine_scripts/puppet/search/actions/merge-contacts.js
+++ b/backstop_data/engine_scripts/puppet/search/actions/merge-contacts.js
@@ -5,7 +5,7 @@ const Page = require('../../page-objects/crm-page.js');
 module.exports = async (engine, scenario, vp) => {
   const page = await Page.build(engine, scenario, vp);
 
-  await require('./common')(page, ['3', '199']);
+  await require('./common')(page, ['103', '88']);
   await engine.waitFor('#search-status .select2-container:not(.select2-container-disabled)');
   await page.clickSelect2Option('#s2id_task', 'Merge contacts');
   await engine.waitForNavigation();

--- a/backstop_data/engine_scripts/puppet/search/find-activities-delete-modal.js
+++ b/backstop_data/engine_scripts/puppet/search/find-activities-delete-modal.js
@@ -6,7 +6,7 @@ module.exports = async (engine, scenario, vp) => {
   const page = await Page.build(engine, scenario, vp);
 
   await require('./find-activities')(engine, scenario, vp);
-  if( !!(await engine.$('.crm-search-results span.crm-hover-button'))) {
+  if (await engine.$('.crm-search-results span.crm-hover-button')) {
     await engine.click('.crm-search-results span.crm-hover-button');
   }
   await page.clickAndWaitForModal('a[title="Delete Activity"]');

--- a/backstop_data/engine_scripts/puppet/search/find-activities-delete-modal.js
+++ b/backstop_data/engine_scripts/puppet/search/find-activities-delete-modal.js
@@ -6,6 +6,5 @@ module.exports = async (engine, scenario, vp) => {
   const page = await Page.build(engine, scenario, vp);
 
   await require('./find-activities')(engine, scenario, vp);
-  await engine.click('.crm-search-results span.crm-hover-button');
   await page.clickAndWaitForModal('a[title="Delete Activity"]');
 };

--- a/backstop_data/engine_scripts/puppet/search/find-activities-delete-modal.js
+++ b/backstop_data/engine_scripts/puppet/search/find-activities-delete-modal.js
@@ -6,5 +6,8 @@ module.exports = async (engine, scenario, vp) => {
   const page = await Page.build(engine, scenario, vp);
 
   await require('./find-activities')(engine, scenario, vp);
+  if( !!(await engine.$('.crm-search-results span.crm-hover-button'))) {
+    await engine.click('.crm-search-results span.crm-hover-button');
+  }
   await page.clickAndWaitForModal('a[title="Delete Activity"]');
 };

--- a/scenarios/contact-page.json
+++ b/scenarios/contact-page.json
@@ -36,11 +36,6 @@
       "url": "{url}/index.php?q=civicrm/contact/view&reset=1&cid=2&selectedChild=participant",
       "selectors": [".ui-dialog"],
       "onReadyScript": "contact-page/record-event.js"
-    },
-    {
-      "label": "Tags",
-      "url": "{url}/index.php?q=civicrm/contact/view&reset=1&cid=2&selectedChild=tag",
-      "onReadyScript": "contact-page/show-tags.js"
     }
   ]
 }


### PR DESCRIPTION
## Overview
This PR contains some minor JS fixes for backstop test suite to work seamless with Default Vanilla CiviCRM (enabled with sample data).

### Technical Details
Fixes following technical issues.

#### Problem1
In Find activity Search result page, the action link delete for vanilla civiCRM comes directly on the right. But because of civicase Component was enabled the delete button comes under the 3 dot menu dropdown on the right and the test case was written for that condition.

<img width="1658" alt="1a" src="https://user-images.githubusercontent.com/3340537/43395592-413ed2c2-941c-11e8-8b2c-130e4ebd241d.png">
<img width="1680" alt="1b" src="https://user-images.githubusercontent.com/3340537/43395595-416b2868-941c-11e8-9ec6-6391c861a455.png">

 
#### Fix1 
 Removed the JS interaction code to open the dropdown so that it directly opens the delete modal.

#### Problem2 
 In Sample data there are no organisation that contains 'Technology' as keyword and hence backstop fails

<img width="1680" alt="2a" src="https://user-images.githubusercontent.com/3340537/43395614-4b647c02-941c-11e8-9594-a3bc8a4cd92b.png">

#### Fix 2
 Removing the the 'Technology' keyword from the search filter while searching. see (puppet/search/actions/common.js). Also updated the Checkbox Ids for matching the scenario.

#### Problem 3
 For Merge contacts scenarios the selection checkbox ids were wrong.

#### Fix 3
 Fixed them to use the correct checkbox ids.

#### Problem4
 Duplicate "Tags" scenario exists. 
 * one in `scenarios/contact-menu.json`
 * one in `scenarios/contact-page.json`
#### Fix 4
 Removed one from `scenarios/contact-page.json`

### Other Details (incl 8332016)

*For Delete Activity scene - Add check to see if the 3 dot dropdown exists then click it open before clicking the delete button. *If Civicase component is enabled it adds an extra action to the activity search search items forcing the delete button to come under a 3 dot dropdown.*

* For search action scenes. - Inside common.js add a keyword for name input field in Search contacts form (Add 'Alliance' as search name keyword) to filter down the search results counts so that it doesn't flood the screen with much results.


