### PR TITLE
SHOR-57: Parallel capture limit fix and Schedule Email issue fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ A CiviCRM site with sample data (check the "Load sample data" option when runnin
 
 ### Drupal
 * [Clean URLs](https://www.drupal.org/docs/7/configuring-clean-urls/enable-clean-urls) enabled
+* The user name for admin should be `admin`
 
 # How to use it
 1. Create a `backstop_data/site-config.json` file with the following content.

--- a/backstop_data/engine_scripts/puppet/search/actions/common.js
+++ b/backstop_data/engine_scripts/puppet/search/actions/common.js
@@ -13,10 +13,10 @@ module.exports = async (page, checkboxIds = ['103']) => {
   await page.clickSelect2Option('#s2id_contact_type', 'Organization');
   await page.engine.type('#sort_name', 'Alliance');
   await page.clickAndWaitForNavigation('#_qf_Basic_refresh');
-  
+
   const onAdvanceSearchPage = !!(await page.engine.$('.CRM_Contact_Form_Search_Advanced'));
 
-  if(onAdvanceSearchPage) {
+  if (onAdvanceSearchPage) {
     await page.clickSelect2Option('#s2id_contact_type', 'Organization');
     await page.engine.type('#sort_name', 'Alliance');
     await page.clickAndWaitForNavigation('#_qf_Advanced_refresh-top');

--- a/backstop_data/engine_scripts/puppet/search/actions/common.js
+++ b/backstop_data/engine_scripts/puppet/search/actions/common.js
@@ -11,9 +11,17 @@
  */
 module.exports = async (page, checkboxIds = ['103']) => {
   await page.clickSelect2Option('#s2id_contact_type', 'Organization');
-  await page.clickAndWaitForNavigation('#_qf_Basic_refresh');
   await page.engine.type('#sort_name', 'Alliance');
+  await page.clickAndWaitForNavigation('#_qf_Basic_refresh');
   
+  const onAdvanceSearchPage = !!(await page.engine.$('.CRM_Contact_Form_Search_Advanced'));
+
+  if(onAdvanceSearchPage) {
+    await page.clickSelect2Option('#s2id_contact_type', 'Organization');
+    await page.engine.type('#sort_name', 'Alliance');
+    await page.clickAndWaitForNavigation('#_qf_Advanced_refresh-top');
+  }
+
   for (const id of checkboxIds) {
     await page.engine.click(`#mark_x_${id}`);
   }

--- a/backstop_data/engine_scripts/puppet/search/actions/common.js
+++ b/backstop_data/engine_scripts/puppet/search/actions/common.js
@@ -16,6 +16,8 @@ module.exports = async (page, checkboxIds = ['103']) => {
 
   /**
    * For parallel captures the search page redirects to advance search.
+   * Reason -  Civicrm invalidates qf_key parameter as the same page is accessed with
+   * different Drupal login sessions with multiple qf_keys passed at the same time.
    * To fix the bug we are checking if page redirects to advance search.
    */
   const onAdvanceSearchPage = !!(await page.engine.$('.CRM_Contact_Form_Search_Advanced'));

--- a/backstop_data/engine_scripts/puppet/search/actions/common.js
+++ b/backstop_data/engine_scripts/puppet/search/actions/common.js
@@ -14,8 +14,13 @@ module.exports = async (page, checkboxIds = ['103']) => {
   await page.engine.type('#sort_name', 'Alliance');
   await page.clickAndWaitForNavigation('#_qf_Basic_refresh');
 
+  /**
+   * For parallel captures the search page redirects to advance search.
+   * To fix the bug we are checking if page redirects to advance search.
+   */
   const onAdvanceSearchPage = !!(await page.engine.$('.CRM_Contact_Form_Search_Advanced'));
 
+  // if page redirects, refill it and submit
   if (onAdvanceSearchPage) {
     await page.clickSelect2Option('#s2id_contact_type', 'Organization');
     await page.engine.type('#sort_name', 'Alliance');

--- a/backstop_data/engine_scripts/puppet/search/actions/email-schedule.js
+++ b/backstop_data/engine_scripts/puppet/search/actions/email-schedule.js
@@ -7,6 +7,7 @@ module.exports = async (engine, scenario, vp) => {
 
   await require('./common')(page);
   await page.clickSelect2Option('#s2id_task', 'Email - schedule/send via CiviMail');
+  await engine.waitForNavigation();
   await engine.waitFor('.crm-wizard', { visible: true });
   await engine.waitFor('.content > .select2-container.crm-group-ref', { visible: true });
   await require('../../common/close-notifications')(engine, scenario, vp);


### PR DESCRIPTION
## Overview
* Parallel capture limit fix and schedule email issue fixes.
* Update readme with Drupal user name requirement.

### Technical Details
#### Problem 1
When running backstop with parallel captures upto 5, `search-actions` group tests fails with some errors because sometimes contact search form on clicking on search results redirects to advance search rather than results page.
After having it discussed with the civicrm dev team, we discovered that civicrm is invalidating `qf_key` parameter as the same page is accessed with different Drupal login sessions with multiple `qf_keys` passed.
Dev channel discussion thread 
-  https://chat.civicrm.org/civicrm/pl/q85ts7uu3ffqmmktaawcgrhyrr

#### Fix 1
Through backstop we are checking if the page is being redirected to the advance search and if yes then we refill the advance search form with the same filter options as basic search and then search for the results.
***Note**: This is not the actual fix for the problem but is a hack to fix this for multiple parallel captures. *

--------------------------------------------------------------------------------------------------
#### Problem 2.
For Email schedule Scene we are directly waiting for the `.crm-wizard` div which appears on the next page. This sometimes (in parallel captures or slow network speed) take more than `3000ms` (which is default timeout for `waitFor` function) and throws error. 

#### Fix 2 
To fix this the best way is to wait for the page to navigate to the next page and then wait for `.crm-wizard` div.
