### PR TITLE
SHOR-58: Misc improvements and fixes

### DIFF
--- a/backstop_data/backstop.tpl.json
+++ b/backstop_data/backstop.tpl.json
@@ -15,7 +15,7 @@
   },
   "engine": "puppeteer",
   "report": ["CLI", "browser"],
-  "asyncCaptureLimit": 1,
+  "asyncCaptureLimit": 2,
   "asyncCompareLimit": 50,
   "debug": false,
   "debugWindow": false,

--- a/backstop_data/engine_scripts/puppet/contact/add-tag.js
+++ b/backstop_data/engine_scripts/puppet/contact/add-tag.js
@@ -5,5 +5,5 @@ const Page = require('../page-objects/crm-page.js');
 module.exports = async (engine, scenario, vp) => {
   const page = await Page.build(engine, scenario, vp);
 
-  await page.clickAndWaitForModal('a[href^="/civicrm/tag/edit?action=add"]');
+  await page.clickAndWaitForModal('a[href*="/civicrm/tag/edit?action=add"]');
 };

--- a/backstop_data/engine_scripts/puppet/contact/clone-tags-modal.js
+++ b/backstop_data/engine_scripts/puppet/contact/clone-tags-modal.js
@@ -5,7 +5,7 @@ const Page = require('../page-objects/crm-page.js');
 module.exports = async (engine, scenario, vp) => {
   const page = await Page.build(engine, scenario, vp);
 
-  await engine.waitFor('a[href^="/civicrm/tag/edit?action=add"]', { visible: true });
+  await engine.waitFor('a[href*="/civicrm/tag/edit?action=add"]', { visible: true });
   await engine.click('.jstree-node .jstree-wholerow');
   await page.clickAndWaitForModal('a[title="Duplicate ths tag"');
 };

--- a/backstop_data/engine_scripts/puppet/contact/delete-tags-modal.js
+++ b/backstop_data/engine_scripts/puppet/contact/delete-tags-modal.js
@@ -5,7 +5,7 @@ const Page = require('../page-objects/crm-page.js');
 module.exports = async (engine, scenario, vp) => {
   const page = await Page.build(engine, scenario, vp);
 
-  await engine.waitFor('a[href^="/civicrm/tag/edit?action=add"]', { visible: true });
+  await engine.waitFor('a[href*="/civicrm/tag/edit?action=add"]', { visible: true });
   await engine.click('.jstree-node .jstree-wholerow');
   await page.clickAndWaitForModal('a[href*="/civicrm/tag/edit?action=delete"');
 };

--- a/scenarios/contact-page.json
+++ b/scenarios/contact-page.json
@@ -12,7 +12,6 @@
     {
       "label": "Record Contribution",
       "url": "{url}/index.php?q=civicrm/contact/view&reset=1&cid=2&selectedChild=contribute",
-      "selectors": [".ui-dialog"],
       "onReadyScript": "contact-page/record-contribution.js"
     },
     {
@@ -23,7 +22,6 @@
     {
       "label": "Memberships - Add Membership",
       "url": "{url}/index.php?q=civicrm/contact/view&reset=1&cid=2&selectedChild=member",
-      "selectors": [".ui-dialog"],
       "onReadyScript": "contact-page/record-membership.js"
     },
     {
@@ -34,7 +32,6 @@
     {
       "label": "Events - Add Membership",
       "url": "{url}/index.php?q=civicrm/contact/view&reset=1&cid=2&selectedChild=participant",
-      "selectors": [".ui-dialog"],
       "onReadyScript": "contact-page/record-event.js"
     }
   ]


### PR DESCRIPTION
# Overview
This PR adds some miscellaneous improvements and fixes to the test suite

## Improved capture of modals in contact summary page
### Before
The screenshots of the modals were taken by cropping around the `.ui-dialog` element (the outermost element of a modal.  This unfortunately caused BackstopJS not to spot that an entire portion of the modal was missing, like in the case of https://github.com/civicrm/org.civicrm.shoreditch/pull/272

<img width="700" alt="before" src="https://user-images.githubusercontent.com/6400898/43763310-be55e0e8-9a2a-11e8-885b-8251e59c38d0.png">

By taking a screenshot of the whole page instead of cropping it, the issue is correctly detected

<img width="700" alt="after" src="https://user-images.githubusercontent.com/6400898/43763308-be3c8abc-9a2a-11e8-916a-92050e4cad68.png">

## Fixed selector for "add tag" button
This selector
```css
a[href^="/civicrm/tag/edit?action=add"]
```
was used in 3 scenarios: 
* Tags - Add Tag
* Tags - Clone Tags
* Tags - Delete Tags Modal

and all would be fail if the site BackstopJS was browsing would be in a sub-folder, because the selector would not much the `href` of the button anymore

Example
url: localhost:8888/drupal-civi/
href: /drupal-civi/civicrm/tag/edit?action=add

Making the selector less strict fixed the issue
```css
a[href*="/civicrm/tag/edit?action=add"]
```

## Enable parallel capturing by default
Parallel capturing is now enabled by default, with 2 screenshots captured at once

