### PR TITLE
SE-7: Add pages to be opened in new tab for view pledge, contributions and event

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A CiviCRM site with sample data (check the "Load sample data" option when runnin
 * At least one Batch Data Entry Set with type 'Contribution' (/civicrm/batch/add?reset=1&action=add)
 * On Contact search page (/civicrm/contact/search) , the first result should have a valid email address field
 * "Adams Family" contact must be added to Administators group (/civicrm/group/search?context=amtg&amtgID=1&reset=1)
+* At least one pending contribution with a contact.
 
 ### Extensions
 * The [uk.co.vedaconsulting.mosaico](https://github.com/veda-consulting/uk.co.vedaconsulting.mosaico) extension should not be enabled on the site. In case it is, either momentarily disable it or remove the *mailings_menu.json* scenarios group

--- a/backstop_data/engine_scripts/puppet/contributions/new-tab-completed-contribution.js
+++ b/backstop_data/engine_scripts/puppet/contributions/new-tab-completed-contribution.js
@@ -1,0 +1,11 @@
+'use strict';
+
+const Page = require('../page-objects/crm-page.js');
+
+module.exports = async (engine, scenario, vp) => {
+  const page = await Page.build(engine, scenario, vp);
+
+  // Search directly as default value is completed.
+  await page.clickAndWaitForNavigation('#_qf_Search_refresh');
+  await page.openInNewTab('.crm-contact-contribute-contributions > table > tbody > tr:first-child [title="View Contribution"]');
+};

--- a/backstop_data/engine_scripts/puppet/contributions/new-tab-pending-contribution.js
+++ b/backstop_data/engine_scripts/puppet/contributions/new-tab-pending-contribution.js
@@ -1,0 +1,13 @@
+'use strict';
+
+const Page = require('../page-objects/crm-page.js');
+
+module.exports = async (engine, scenario, vp) => {
+  const page = await Page.build(engine, scenario, vp);
+
+  // Reset all options.
+  await page.clickAll('.select2-search-choice-close');
+  await page.clickSelect2Option('#s2id_contribution_status_id', 'Pending');
+  await page.clickAndWaitForNavigation('#_qf_Search_refresh');
+  await page.openInNewTab('.crm-contact-contribute-contributions > table > tbody > tr:first-child [title="View Contribution"]');
+};

--- a/backstop_data/engine_scripts/puppet/contributions/new-tab-view-pledge.js
+++ b/backstop_data/engine_scripts/puppet/contributions/new-tab-view-pledge.js
@@ -1,0 +1,12 @@
+'use strict';
+
+const Page = require('../page-objects/crm-page.js');
+
+module.exports = async (engine, scenario, vp) => {
+  const page = await Page.build(engine, scenario, vp);
+
+  // Search directly as default value is completed.
+  await page.clickAndWaitForNavigation('#_qf_Search_refresh');
+  await page.openInNewTab('.CRM_Pledge_Form_Search table > tbody > tr:first-child [title="View Pledge"]');
+
+};

--- a/backstop_data/engine_scripts/puppet/events/new-tab-view-events.js
+++ b/backstop_data/engine_scripts/puppet/events/new-tab-view-events.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const Page = require('../page-objects/crm-page.js');
+
+module.exports = async (engine, scenario, vp) => {
+  const page = await Page.build(engine, scenario, vp);
+
+  await page.openInNewTab('.CRM_Event_Form_Search > .form-item > table > tbody > tr:first-child [title="View Participation"]');
+};

--- a/backstop_data/engine_scripts/puppet/page-objects/crm-page.js
+++ b/backstop_data/engine_scripts/puppet/page-objects/crm-page.js
@@ -216,6 +216,19 @@ module.exports = class CrmPage {
   }
 
   /**
+   * Opens a fresh page with the link attached to the passed selector. This mimmicks open in a new
+   * tab functionality
+   *
+   * @param {String} selector - the css selector for the element to open in a new tab
+   */
+  async openInNewTab (selector) {
+    const pageUrl = await this.engine.$eval(selector, el => window.location.origin + '/' + el.getAttribute('href'));
+
+    // Open the page url to mimmick open in new tab
+    await this.engine.goto(pageUrl, {waitUntil: 'load'});
+  }
+
+  /**
    * Submits the current page form.
    */
   async submit () {

--- a/scenarios/contributions-menu.json
+++ b/scenarios/contributions-menu.json
@@ -115,6 +115,11 @@
       "onReadyScript": "contributions/new-pledge-filters.js"
     },
     {
+      "label": "Pledges - View Pledge - New tab",
+      "url": "{url}/civicrm/pledge/search?reset=1",
+      "onReadyScript": "contributions/new-tab-view-pledge.js"
+    },
+    {
       "label": "Batch Data Entry",
       "url": "{url}/civicrm/batch?reset=1",
       "onReadyScript": "contributions/batches.js"

--- a/scenarios/contributions-menu.json
+++ b/scenarios/contributions-menu.json
@@ -360,6 +360,16 @@
       "label": "CiviContribute Component Settings",
       "url": "{url}/civicrm/admin/setting/preferences/contribute?reset=1",
       "onReadyScript": "contributions/component-settings.js"
+    },
+    {
+      "label": "Contributions - Completed contributions - New tab",
+      "url": "{url}/civicrm/contribute/search?reset=1",
+      "onReadyScript": "contributions/new-tab-completed-contribution.js"
+    },
+    {
+      "label": "Contributions - Pending contributions - New tab",
+      "url": "{url}/civicrm/contribute/search?reset=1",
+      "onReadyScript": "contributions/new-tab-pending-contribution.js"
     }
   ]
 }

--- a/scenarios/events-menu.json
+++ b/scenarios/events-menu.json
@@ -69,6 +69,11 @@
       "label": "CiviEvent Component Settings",
       "url": "{url}/civicrm/admin/setting/preferences/event?reset=1",
       "onReadyScript": "common/wait-for-civicrm-page.js"
+    },
+    {
+      "label": "Events - View events - New tab",
+      "url": "{url}/civicrm/event?reset=1",
+      "onReadyScript": "events/new-tab-view-events.js"
     }
   ]
 }


### PR DESCRIPTION
## Overview
This PR adds following screens to the backstopjs test suite in a new page (non modal)
* Contributions - Completed contributions
* Contributions - Pending contributions
* Contributions - View pledge
* Events - View events

## Screens added

#### Completed Contributions
![Completed contribution](https://user-images.githubusercontent.com/3340537/77065679-c1fb2b00-6a07-11ea-91b9-56c08257a5ed.png)

#### Pending contributions
![Pending contribution](https://user-images.githubusercontent.com/3340537/77065689-c4f61b80-6a07-11ea-9b5e-cf564191e1cd.png)

#### View Events 
![View Events](https://user-images.githubusercontent.com/3340537/77065693-c6274880-6a07-11ea-90ff-3e64d0a96b38.png)

#### View Pledge
![View Pledge](https://user-images.githubusercontent.com/3340537/77065694-c6bfdf00-6a07-11ea-840a-921fcd1a44f2.png)

## Technical Details
These pages need to be opened in a new page as these actually open as modals. To handle this generically a new page function `openInNewTab` is created.

This gets the href from the anchor selector and open the page in the same tab. This mimics opening in a new tab. See backstop_data/engine_scripts/puppet/page-objects/crm-page.js




