### PR TITLE
CPS-378: Fix Scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,6 @@ A CiviCRM site with sample data (check the "Load sample data" option when runnin
 * At least one Price Set added with at least one price set (/civicrm/admin/price/), with at least one price field (/civicrm/admin/price/field)
 * At least one Batch Data Entry Set with type 'Contribution' (/civicrm/batch/add?reset=1&action=add)
 * On Contact search page (/civicrm/contact/search) , the first result should have a valid email address field
-* "Adams Family" contact must be added to Administators group (/civicrm/group/search?context=amtg&amtgID=1&reset=1)
 * At least one pending contribution with a contact.
 
 ### Extensions

--- a/backstop_data/engine_scripts/puppet/dashboard/show.js
+++ b/backstop_data/engine_scripts/puppet/dashboard/show.js
@@ -1,6 +1,5 @@
 'use strict';
 
 module.exports = async (engine, scenario, vp) => {
-  await require('../common/wait-for-editable-icon')(engine, scenario, vp);
-  await engine.waitForSelector('.blockUI.blockOverlay', { hidden: true });
+  await engine.waitForSelector('#crm-dashboard-configure');
 };

--- a/backstop_data/engine_scripts/puppet/find-contributions/delete-modal.js
+++ b/backstop_data/engine_scripts/puppet/find-contributions/delete-modal.js
@@ -6,5 +6,6 @@ module.exports = async (engine, scenario, vp) => {
   const page = await Page.build(engine, scenario, vp);
 
   await require('./search')(engine, scenario, vp);
-  await page.clickAndWaitForModal(' a[title="Delete Contribution"]');
+  await engine.click('th[title="Select Rows"] > .crm-form-checkbox');
+  await engine.evaluate(()=>document.querySelector('a[title="Delete Contribution"]').click());
 };

--- a/backstop_data/engine_scripts/puppet/mailings/ab-test-manage.js
+++ b/backstop_data/engine_scripts/puppet/mailings/ab-test-manage.js
@@ -4,6 +4,6 @@ module.exports = async (engine, scenario, vp) => {
   await engine.waitFor('table.display', { visible: true });
   // The list grows on each passing run, so we display only 2 rows in the test (First being the main row);
   await engine.evaluate(() => {
-    document.querySelectorAll('table.display tr:nth-child(n+3)').forEach(row => row.remove());
+    document.querySelectorAll('table.display tr:nth-child(n+1)').forEach(row => row.remove());
   });
 };

--- a/backstop_data/engine_scripts/puppet/manage-groups/add-contacts-to-group-results.js
+++ b/backstop_data/engine_scripts/puppet/manage-groups/add-contacts-to-group-results.js
@@ -7,6 +7,5 @@ module.exports = async (engine, scenario, vp) => {
 
   await require('./add-contacts-to-group-search-form')(engine, scenario, vp);
   await engine.waitForSelector('input[name="sort_name"]', {visible: true});
-  await engine.type('input[name="sort_name"]', 'Adams family');
   await page.clickAndWaitForNavigation('#_qf_Basic_refresh');
 };

--- a/backstop_data/engine_scripts/puppet/search/actions/add-to-household.js
+++ b/backstop_data/engine_scripts/puppet/search/actions/add-to-household.js
@@ -6,6 +6,6 @@ module.exports = async (engine, scenario, vp) => {
   const page = await Page.build(engine, scenario, vp);
 
   await require('./common')(page);
-  await page.clickSelect2Option('#s2id_task', 'Add relationship - to household');
+  await page.clickSelect2Option('#s2id_task', 'Add relationship - to Household');
   await engine.waitForNavigation();
 };

--- a/backstop_data/engine_scripts/puppet/search/actions/add-to-organization.js
+++ b/backstop_data/engine_scripts/puppet/search/actions/add-to-organization.js
@@ -6,6 +6,6 @@ module.exports = async (engine, scenario, vp) => {
   const page = await Page.build(engine, scenario, vp);
 
   await require('./common')(page);
-  await page.clickSelect2Option('#s2id_task', 'Add relationship - to organization');
+  await page.clickSelect2Option('#s2id_task', 'Add relationship - to Organization');
   await engine.waitForNavigation();
 };

--- a/backstop_data/engine_scripts/puppet/search/actions/common.js
+++ b/backstop_data/engine_scripts/puppet/search/actions/common.js
@@ -7,11 +7,10 @@
  * as a way to improve performance
  *
  * @param {CrmPage} page
- * @param {Array} checkboxIds
+ * @param {number} numberOfRecords
  */
-module.exports = async (page, checkboxIds = ['151']) => {
+module.exports = async (page, numberOfRecords = 1) => {
   await page.clickSelect2Option('#s2id_contact_type', 'Organization');
-  await page.engine.type('#sort_name', 'Alliance');
   await page.clickAndWaitForNavigation('#_qf_Basic_refresh');
 
   /**
@@ -25,12 +24,11 @@ module.exports = async (page, checkboxIds = ['151']) => {
   // if page redirects, refill it and submit
   if (onAdvanceSearchPage) {
     await page.clickSelect2Option('#s2id_contact_type', 'Organization');
-    await page.engine.type('#sort_name', 'Alliance');
     await page.clickAndWaitForNavigation('#_qf_Advanced_refresh-top');
   }
 
-  for (const id of checkboxIds) {
-    await page.engine.click(`#mark_x_${id}`);
+  for(var i = 1; i <= numberOfRecords; i++) {
+    await page.engine.click(`.crm-search-results tbody tr:nth-child(${i}) .crm-form-checkbox`);
   }
 
   await page.engine.waitFor('#search-status .select2-container:not(.select2-container-disabled)');

--- a/backstop_data/engine_scripts/puppet/search/actions/merge-contacts.js
+++ b/backstop_data/engine_scripts/puppet/search/actions/merge-contacts.js
@@ -5,7 +5,7 @@ const Page = require('../../page-objects/crm-page.js');
 module.exports = async (engine, scenario, vp) => {
   const page = await Page.build(engine, scenario, vp);
 
-  await require('./common')(page, ['151', '182']);
+  await require('./common')(page, 2);
   await engine.waitFor('#search-status .select2-container:not(.select2-container-disabled)');
   await page.clickSelect2Option('#s2id_task', 'Merge contacts');
   await engine.waitForNavigation();

--- a/scenarios/contributions-menu.json
+++ b/scenarios/contributions-menu.json
@@ -45,7 +45,6 @@
     {
       "label": "Find Contributions - Delete contribution Modal - Results",
       "url": "{url}/civicrm/contribute/search?reset=1",
-      "selectors": [".ui-dialog"],
       "onReadyScript": "find-contributions/delete-modal.js"
     },
     {

--- a/scenarios/search-menu.json
+++ b/scenarios/search-menu.json
@@ -238,18 +238,6 @@
       "onReadyScript": "search/custom-search.js"
     },
     {
-      "label": "Custom Searches - Basic Search",
-      "url": "{url}/civicrm/contact/search/custom?csid=3&reset=1",
-      "hideSelectors": ["#mainTabContainer"],
-      "onReadyScript": "common/wait-for-civicrm-page.js"
-    },
-    {
-      "label": "Custom Searches - Basic Search - result",
-      "url": "{url}/civicrm/contact/search/custom?csid=3&reset=1",
-      "hideSelectors": ["#mainTabContainer"],
-      "onReadyScript": "search/custom-search-basic.js"
-    },
-    {
       "label": "Custom Searches - Include / Exclude Search",
       "url": "{url}/civicrm/contact/search/custom?csid=4&reset=1",
       "hideSelectors": ["#mainTabContainer"],


### PR DESCRIPTION
## Overview
Many of the Backstop JS scenarios stopped working as they were not updated for a long time. This PR fixes that.

## Technical Details
**`Find Contributions - Delete contribution Modal - Results`**
To fix this scenario, changed the selector in `backstop_data/engine_scripts/puppet/find-contributions/delete-modal.js`.

**`Manage Groups - Add Contacts to the group form - View selected contacts - results`**
To fix this scenario, removed the search string "Adams family" from `backstop_data/engine_scripts/puppet/manage-groups/add-contacts-to-group-results.js`. This is done because a contact is not always present with the name "Adams family". So now there is no need to manually create this contact.

**`Dashboard`**
To fix this scenario, changed the selector in `backstop_data/engine_scripts/puppet/dashboard/show.js`.

**`Custom Searches - Basic Search` and `Custom Searches - Basic Search - result`**
Removed both the scenarios, because these pages does not exist anymore. Checked in `https://dmaster.demo.civicrm.org` site too.

**`search-actions.json`**
Fixed many scenarios of this JSON file.
1. In `backstop_data/engine_scripts/puppet/search/actions/add-to-household.js` and `backstop_data/engine_scripts/puppet/search/actions/add-to-organization.js` changed the label of the dropdown items.

2. Changed the logic in `backstop_data/engine_scripts/puppet/search/actions/common.js`. Previously it always expected an ID, but the ID is not same in every build, and its missing most of the time. So now it picks up the first N number of records from the search results.

**`New A/B Test` and `Manage A/B Tests`**
Fixed these scenarios, but making changes to `backstop_data/engine_scripts/puppet/mailings/ab-test-manage.js`.