### PR TITLE
CPS-393: Fix Github Action

### DIFF
--- a/.github/workflows/backstop.yml
+++ b/.github/workflows/backstop.yml
@@ -71,6 +71,7 @@ jobs:
         working-directory: ${{ env.REFERENCE_SITE_FOLDER }}/${{ env.CIVICRM_EXTENSIONS_DIR }}
         run: |
           git clone https://github.com/civicrm/org.civicrm.shoreditch.git --branch ${{ github.event.inputs.reference_shoreditch_branch }}
+          cd org.civicrm.shoreditch
           npm install
           npx gulp sass
           cv en shoreditch
@@ -105,6 +106,7 @@ jobs:
         working-directory: ${{ env.TEST_SITE_FOLDER }}/${{ env.CIVICRM_EXTENSIONS_DIR }}
         run: |
           git clone https://github.com/civicrm/org.civicrm.shoreditch.git --branch ${{ github.event.inputs.test_shoreditch_branch }}
+          cd org.civicrm.shoreditch
           npm install
           npx gulp sass
           cv en shoreditch


### PR DESCRIPTION
## Overview
In the previous PR https://github.com/compucorp/backstopjs-config/pull/48, the step to move inside the Shoreditch folder was missing. This PR fixes that.

## Before/After
Not needed

## Technical Overview
Added the following steps before running `npm install`
```
cd org.civicrm.shoreditch
```