### PR TITLE
CATL-1660: Fix github action

### DIFF
--- a/.github/workflows/backstop.yml
+++ b/.github/workflows/backstop.yml
@@ -74,6 +74,9 @@ jobs:
         run: |
           git clone https://github.com/civicrm/org.civicrm.shoreditch.git --branch ${{ github.event.inputs.reference_shoreditch_branch }}
           cd org.civicrm.shoreditch
+          [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+          nvm install
+          nvm use
           npm install
           npx gulp sass
           cv en shoreditch
@@ -113,6 +116,9 @@ jobs:
         run: |
           git clone https://github.com/civicrm/org.civicrm.shoreditch.git --branch ${{ github.event.inputs.test_shoreditch_branch }}
           cd org.civicrm.shoreditch
+          [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+          nvm install
+          nvm use
           npm install
           npx gulp sass
           cv en shoreditch


### PR DESCRIPTION
## Overview
Backstop JS Github Action was not working after https://github.com/compucorp/backstopjs-config/pull/50. Because correct node version was not installed before installing shoreditch.

Tested that its working fine https://github.com/compucorp/backstopjs-config/actions/runs/751000264