### PR TITLE
RSE-1608: Add scenario for save fields after exporting contacts

### DIFF
--- a/backstop_data/engine_scripts/puppet/search/actions/export-contact-save-fields.js
+++ b/backstop_data/engine_scripts/puppet/search/actions/export-contact-save-fields.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const Page = require('../../page-objects/crm-page.js');
+
+module.exports = async (engine, scenario, vp) => {
+  const page = await Page.build(engine, scenario, vp);
+
+  await require('./export-contact')(engine, scenario, vp);
+  await engine.click('#CIVICRM_QFID_2_exportOption');
+  await page.clickAndWaitForNavigation('#_qf_Select_next-bottom');
+
+  await page.clickSelect2Option('#s2id_autogen3', 'Addressee');
+  await engine.click('.ng-binding.crm-button');
+};

--- a/scenarios/search-actions.json
+++ b/scenarios/search-actions.json
@@ -94,6 +94,11 @@
       "onReadyScript": "search/actions/export-contact.js"
     },
     {
+      "label": "Export contacts - Save fields",
+      "url": "{url}/civicrm/contact/search?reset=1",
+      "onReadyScript": "search/actions/export-contact-save-fields.js"
+    },
+    {
       "label": "Export contact - Step 3",
       "url": "{url}/civicrm/contact/search?reset=1",
       "onReadyScript": "search/actions/export-contact-step-3.js"


### PR DESCRIPTION
## Overview
This PR adds the scenario to test the modal field displayed while saving a set of fields from a contact export action.

## Before
The scenario was not present.

## After
The scenario is present and the screenshot generated after running the reference command.

## Technical Details
The code was based on the existing script `export-contact-step-3.js`. Later were added the steps for selecting one field to be saved, and clicking the (now visible) "Save Fields" button.
